### PR TITLE
[FIX]: remove duplicated argument

### DIFF
--- a/library/src/iosMain/kotlin/com/simplito/java/privmx_endpoint/modules/thread/ThreadApi.ios.kt
+++ b/library/src/iosMain/kotlin/com/simplito/java/privmx_endpoint/modules/thread/ThreadApi.ios.kt
@@ -79,7 +79,6 @@ actual class ThreadApi actual constructor(connection: Connection) : AutoCloseabl
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs(
             threadId?.pson,
-            threadId?.pson,
             users!!.map { it!!.pson }.pson,
             managers!!.map { it!!.pson }.pson,
             publicMeta!!.pson,


### PR DESCRIPTION
## Description
In the `ThreadApi.ios.kt` class - in `updateThread` method deleted duplicated value (threadId).
