### PR TITLE
[REFACTOR]: make connection constructor private

### DIFF
--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.ios.kt
@@ -32,7 +32,7 @@ import libprivmxendpoint.pson_free_result
 import libprivmxendpoint.pson_free_value
 
 @OptIn(ExperimentalForeignApi::class)
-actual class Connection() : AutoCloseable {
+actual class Connection private constructor() : AutoCloseable {
     private val _nativeConnection = nativeHeap.allocPointerTo<cnames.structs.Connection>()
     private val nativeConnection
         get() = _nativeConnection.value?.let { _nativeConnection }


### PR DESCRIPTION
## Description
Set `private` access modifier for constructor of class Connection.