### PR TITLE
fix(privmx-endpoint/ios): `delete` field initialization in policies parsers

### DIFF
--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersFromPson.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersFromPson.kt
@@ -116,7 +116,7 @@ internal fun PsonObject.toContainerPolicy(): ContainerPolicy =
     ContainerPolicy(
         this["get"]?.typedValue(),
         this["update"]?.typedValue(),
-        this["delete"]?.typedValue(),
+        this["delete_"]?.typedValue(),
         this["updatePolicy"]?.typedValue(),
         this["updaterCanBeRemovedFromManagers"]?.typedValue(),
         this["ownerCanBeRemovedFromManagers"]?.typedValue(),
@@ -137,7 +137,7 @@ internal fun PsonObject.toItemPolicy(): ItemPolicy = ItemPolicy(
     this["listAll"]?.typedValue(),
     this["create"]?.typedValue(),
     this["update"]?.typedValue(),
-    this["delete"]?.typedValue()
+    this["delete_"]?.typedValue()
 )
 
 internal fun PsonObject.toMessage() = Message(

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersToPson.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersToPson.kt
@@ -24,7 +24,7 @@ internal val ItemPolicy.pson: PsonValue.PsonObject
         "listAll" to listAll.nullablePson,
         "create" to create.nullablePson,
         "update" to update.nullablePson,
-        "delete" to delete.nullablePson,
+        "delete_" to delete.nullablePson,
     ).pson
 
 
@@ -38,7 +38,7 @@ internal val ContainerPolicy.pson: PsonValue.PsonObject
     get() = mapOfWithNulls(
         "get" to get.nullablePson,
         "update" to update.nullablePson,
-        "delete" to delete.nullablePson,
+        "delete_" to delete.nullablePson,
         "updatePolicy" to updatePolicy.nullablePson,
         "updaterCanBeRemovedFromManagers" to updaterCanBeRemovedFromManagers.nullablePson,
         "ownerCanBeRemovedFromManagers" to ownerCanBeRemovedFromManagers.nullablePson,
@@ -49,7 +49,7 @@ internal val ContainerPolicyWithoutItem.pson: PsonValue.PsonObject
     get() = mapOfWithNulls(
         "get" to get.nullablePson,
         "update" to update.nullablePson,
-        "delete" to delete.nullablePson,
+        "delete_" to delete.nullablePson,
         "updatePolicy" to updatePolicy.nullablePson,
         "updaterCanBeRemovedFromManagers" to updaterCanBeRemovedFromManagers.nullablePson,
         "ownerCanBeRemovedFromManagers" to ownerCanBeRemovedFromManagers.nullablePson,


### PR DESCRIPTION
Closes #66 