### PR TITLE
Release 2.2.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-publishPrivmxEndpoint = "2.2.0"
+publishPrivmxEndpoint = "2.2.1"
 kotlinxIoCore = "0.7.0"
 kotlin-serialization = "2.1.20"
 serialization-json = "1.8.1"

--- a/privmx-endpoint-extra/build.gradle.kts
+++ b/privmx-endpoint-extra/build.gradle.kts
@@ -54,7 +54,7 @@ publishing {
             pom {
                 name = "PrivMX Endpoint Kotlin Extra"
                 description =
-                    "PrivMX Endpoint Kotlin Extra is an extension of Privmx Endpoint Kotlin. It's extended with additional logic that makes using our libraries simpler and less error-prone."
+                    "PrivMX Endpoint Kotlin Extra is an extension of PrivMX Endpoint Kotlin. It's extended with additional logic that makes using our libraries simpler and less error-prone."
             }
         }
     }

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.ios.kt
@@ -209,7 +209,7 @@ actual class Connection private constructor() : AutoCloseable {
         try {
             disconnect()
         } catch (e: PrivmxException) {
-            //if endpoint not throw exception about disconnected state
+            //if PrivMX Endpoint doesn’t throw exception about disconnected state
             if (e.getCode() != 131073u) throw e
         }
         privmx_endpoint_freeConnection(nativeConnection.value)

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.ios.kt
@@ -204,7 +204,8 @@ actual class Connection private constructor() : AutoCloseable {
      * disconnects from PrivMX Bridge and frees memory making this instance not reusable.
      */
     actual override fun close() {
-        if (_nativeConnection.value == null) return
+        //Throws if native connection are closed
+        nativeConnection
         try {
             disconnect()
         } catch (e: PrivmxException) {

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.ios.kt
@@ -166,12 +166,13 @@ actual class Connection private constructor() : AutoCloseable {
      */
     @Throws( PrivmxException::class, NativeException::class, IllegalStateException::class)
     actual fun disconnect() = memScoped {
-        val args = pson_new_object()
+        val args = makeArgs()
         val result = allocPointerTo<pson_value>().apply {
             value = pson_new_object()
         }
         try {
             privmx_endpoint_execConnection(nativeConnection.value, 4, args, result.ptr)
+            result.value?.asResponse?.getResultOrThrow()
             Unit
         } finally {
             pson_free_value(args)
@@ -204,7 +205,12 @@ actual class Connection private constructor() : AutoCloseable {
      */
     actual override fun close() {
         if (_nativeConnection.value == null) return
-        disconnect()
+        try {
+            disconnect()
+        } catch (e: PrivmxException) {
+            //if endpoint not throw exception about disconnected state
+            if (e.getCode() != 131073u) throw e
+        }
         privmx_endpoint_freeConnection(nativeConnection.value)
         _nativeConnection.value = null
     }

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.ios.kt
@@ -323,8 +323,7 @@ actual class CryptoApi : AutoCloseable {
      * @throws Exception when instance is currently closed.
      */
     actual override fun close() {
-        if (_nativeCryptoApi.value == null) return
-        privmx_endpoint_freeCryptoApi(_nativeCryptoApi.value)
+        privmx_endpoint_freeCryptoApi(nativeCryptoApi.value)
         _nativeCryptoApi.value = null
     }
 }

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/inbox/InboxApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/inbox/InboxApi.ios.kt
@@ -735,8 +735,7 @@ actual constructor(
      * @throws Exception when instance is currently closed
      */
     actual override fun close() {
-        if (_nativeInboxApi.value == null) return
-        privmx_endpoint_freeInboxApi(_nativeInboxApi.value)
+        privmx_endpoint_freeInboxApi(nativeInboxApi.value)
         _nativeInboxApi.value = null
     }
 }

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/inbox/InboxApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/inbox/InboxApi.ios.kt
@@ -73,31 +73,17 @@ actual constructor(
 
     init {
         val tmpThreadApi = if (threadApi == null) {
-            memScoped {
-                allocPointerTo<cnames.structs.ThreadApi>().apply {
-                    privmx_endpoint_newThreadApi(
-                        connection.getConnectionPtr(),
-                        ptr,
-                    )
-                }
-            }
+            ThreadApi(connection)
         } else null
 
         val tmpStoreApi = if (storeApi == null) {
-            memScoped {
-                allocPointerTo<cnames.structs.StoreApi>().apply {
-                    privmx_endpoint_newStoreApi(
-                        connection.getConnectionPtr(),
-                        ptr,
-                    )
-                }
-            }
+            StoreApi(connection)
         } else null
 
         privmx_endpoint_newInboxApi(
             connection.getConnectionPtr(),
-            threadApi?.getThreadPtr(),
-            storeApi?.getStorePtr(),
+            (threadApi ?: tmpThreadApi)?.getThreadPtr(),
+            (storeApi ?: tmpStoreApi)?.getStorePtr(),
             _nativeInboxApi.ptr
         )
 
@@ -110,8 +96,8 @@ actual constructor(
             } finally {
                 pson_free_value(args)
                 pson_free_result(pson_result.value)
-                tmpThreadApi?.let { privmx_endpoint_freeThreadApi(it.value) }
-                tmpStoreApi?.let { privmx_endpoint_freeStoreApi(it.value) }
+                tmpThreadApi?.close()
+                tmpStoreApi?.close()
             }
         }
     }

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/inbox/InboxApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/inbox/InboxApi.ios.kt
@@ -199,7 +199,6 @@ actual constructor(
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs(
             inboxId.pson,
-            inboxId.pson,
             users.map { it.pson }.pson,
             managers.map { it.pson }.pson,
             publicMeta.pson,

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/store/StoreApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/store/StoreApi.ios.kt
@@ -743,8 +743,7 @@ actual constructor(connection: Connection) :
      * @throws Exception when instance is currently closed
      */
     actual override fun close() {
-        if (_nativeStoreApi.value == null) return
-        privmx_endpoint_freeStoreApi(_nativeStoreApi.value)
+        privmx_endpoint_freeStoreApi(nativeStoreApi.value)
         _nativeStoreApi.value = null
     }
 }

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/thread/ThreadApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/thread/ThreadApi.ios.kt
@@ -506,8 +506,7 @@ actual constructor(connection: Connection) : AutoCloseable {
      * @throws Exception when instance is currently closed
      */
     actual override fun close() {
-        if (_nativeThreadApi.value == null) return
-        privmx_endpoint_freeThreadApi(_nativeThreadApi.value)
+        privmx_endpoint_freeThreadApi(nativeThreadApi.value)
         _nativeThreadApi.value = null
     }
 }

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersFromPson.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersFromPson.kt
@@ -116,7 +116,7 @@ internal fun PsonObject.toContainerPolicy(): ContainerPolicy =
     ContainerPolicy(
         this["get"]?.typedValue(),
         this["update"]?.typedValue(),
-        this["delete"]?.typedValue(),
+        this["delete_"]?.typedValue(),
         this["updatePolicy"]?.typedValue(),
         this["updaterCanBeRemovedFromManagers"]?.typedValue(),
         this["ownerCanBeRemovedFromManagers"]?.typedValue(),
@@ -137,7 +137,7 @@ internal fun PsonObject.toItemPolicy(): ItemPolicy = ItemPolicy(
     this["listAll"]?.typedValue(),
     this["create"]?.typedValue(),
     this["update"]?.typedValue(),
-    this["delete"]?.typedValue()
+    this["delete_"]?.typedValue()
 )
 
 internal fun PsonObject.toMessage() = Message(

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersToPson.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersToPson.kt
@@ -24,7 +24,7 @@ internal val ItemPolicy.pson: PsonValue.PsonObject
         "listAll" to listAll.nullablePson,
         "create" to create.nullablePson,
         "update" to update.nullablePson,
-        "delete" to delete.nullablePson,
+        "delete_" to delete.nullablePson,
     ).pson
 
 
@@ -38,7 +38,7 @@ internal val ContainerPolicy.pson: PsonValue.PsonObject
     get() = mapOfWithNulls(
         "get" to get.nullablePson,
         "update" to update.nullablePson,
-        "delete" to delete.nullablePson,
+        "delete_" to delete.nullablePson,
         "updatePolicy" to updatePolicy.nullablePson,
         "updaterCanBeRemovedFromManagers" to updaterCanBeRemovedFromManagers.nullablePson,
         "ownerCanBeRemovedFromManagers" to ownerCanBeRemovedFromManagers.nullablePson,
@@ -49,7 +49,7 @@ internal val ContainerPolicyWithoutItem.pson: PsonValue.PsonObject
     get() = mapOfWithNulls(
         "get" to get.nullablePson,
         "update" to update.nullablePson,
-        "delete" to delete.nullablePson,
+        "delete_" to delete.nullablePson,
         "updatePolicy" to updatePolicy.nullablePson,
         "updaterCanBeRemovedFromManagers" to updaterCanBeRemovedFromManagers.nullablePson,
         "ownerCanBeRemovedFromManagers" to ownerCanBeRemovedFromManagers.nullablePson,


### PR DESCRIPTION
# Description
## PrivMX Endpoint
### iOS
#### FEAT
* unify close method behavior in container classes with JVM implementation by @djenczewski in https://github.com/simplito/privmx-endpoint-kotlin/pull/73
#### FIX
* `delete` field initialization in policies parsers by @djenczewski in https://github.com/simplito/privmx-endpoint-kotlin/pull/71
* no exceptions thrown and issues with disconnecting in Connection class by @djenczewski in https://github.com/simplito/privmx-endpoint-kotlin/pull/70
* Segmentation fault error in InboxApi constructor when ThreadApi and StoreApi arguments are null by @djenczewski in https://github.com/simplito/privmx-endpoint-kotlin/pull/72