### PR TITLE
Fix/2.3.0 implementation

### DIFF
--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/BIP39.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/BIP39.kt
@@ -1,4 +1,4 @@
-package com.simplito.java.privmx_endpoint.model
+package com.simplito.kotlin.privmx_endpoint.model
 
 import com.simplito.kotlin.privmx_endpoint.modules.crypto.ExtKey
 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.kt
@@ -15,7 +15,7 @@ import com.simplito.kotlin.privmx_endpoint.model.Context
 import com.simplito.kotlin.privmx_endpoint.model.PKIVerificationOptions
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.UserInfo
-import com.simplito.kotlin.privmx_endpoint.model.UserVerifierInterface
+import com.simplito.kotlin.privmx_endpoint.modules.core.UserVerifierInterface
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/UserVerifierInterface.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/UserVerifierInterface.kt
@@ -1,10 +1,12 @@
-package com.simplito.kotlin.privmx_endpoint.model
+package com.simplito.kotlin.privmx_endpoint.modules.core
+
+import com.simplito.kotlin.privmx_endpoint.model.VerificationRequest
 
 /**
  * UserVerifierInterface - an interface consisting of a single verify() method, which - when implemented - should perform verification of the provided data using an external service verification
  * should be done using an external service such as an application server or a PKI server.
  */
-interface UserVerifierInterface {
+fun interface UserVerifierInterface {
     /**
      * Verifies whether the specified users are valid.
      * Checks if each user belonged to the Context and if this is their key in `date` and return `true` or `false` otherwise.

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.kt
@@ -10,7 +10,7 @@
 //
 package com.simplito.kotlin.privmx_endpoint.modules.crypto
 
-import com.simplito.java.privmx_endpoint.model.BIP39
+import com.simplito.kotlin.privmx_endpoint.model.BIP39
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.kt
@@ -134,7 +134,7 @@ expect class CryptoApi() : AutoCloseable {
      * @return BIP39 object containing ECC Key and associated with it BIP-39 mnemonic and entropy
      */
     @Throws(PrivmxException::class, NativeException::class)
-    fun generateBip39(strength: Long?, password: String = ""): BIP39
+    fun generateBip39(strength: Long, password: String = ""): BIP39
 
     /**
      * Generates ECC key using BIP-39 mnemonic.

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.ios.kt
@@ -16,7 +16,7 @@ import com.simplito.kotlin.privmx_endpoint.model.Context
 import com.simplito.kotlin.privmx_endpoint.model.PKIVerificationOptions
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.UserInfo
-import com.simplito.kotlin.privmx_endpoint.model.UserVerifierInterface
+import com.simplito.kotlin.privmx_endpoint.modules.core.UserVerifierInterface
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.utils.KPSON_NULL

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/UserVerifierInterface.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/UserVerifierInterface.ios.kt
@@ -1,7 +1,7 @@
 package com.simplito.kotlin.privmx_endpoint.modules.core
 
 import cnames.structs.pson_value
-import com.simplito.kotlin.privmx_endpoint.model.UserVerifierInterface
+import com.simplito.kotlin.privmx_endpoint.modules.core.UserVerifierInterface
 import com.simplito.kotlin.privmx_endpoint.utils.PsonValue
 import com.simplito.kotlin.privmx_endpoint.utils.asArgs
 import com.simplito.kotlin.privmx_endpoint.utils.pson

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.ios.kt
@@ -343,7 +343,7 @@ actual class CryptoApi : AutoCloseable {
 
     @Throws(PrivmxException::class, NativeException::class)
     actual fun generateBip39(
-        strength: Long?,
+        strength: Long,
         password: String
     ): BIP39 = memScoped {
         val pson_result = allocPointerTo<pson_value>()

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.ios.kt
@@ -12,7 +12,7 @@
 package com.simplito.kotlin.privmx_endpoint.modules.crypto
 
 import cnames.structs.pson_value
-import com.simplito.java.privmx_endpoint.model.BIP39
+import com.simplito.kotlin.privmx_endpoint.model.BIP39
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.utils.PsonValue

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/ExtKey.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/ExtKey.ios.kt
@@ -36,16 +36,21 @@ actual class ExtKey private constructor() : AutoCloseable {
     }
 
     actual companion object {
+        private val _companionNativeExtKey: CPointerVar<cnames.structs.ExtKey> by lazy {
+            nativeHeap.allocPointerTo<cnames.structs.ExtKey>().apply {
+                privmx_endpoint_newExtKey(ptr)
+            }
+        }
+
         @Throws(PrivmxException::class, NativeException::class)
         actual fun fromSeed(seed: ByteArray): ExtKey = memScoped {
             val pson_result = allocPointerTo<pson_value>()
             val args = makeArgs(seed.pson)
             try {
-                ExtKey().apply {
-                    privmx_endpoint_newExtKey(_nativeExtKey.ptr)
-                    privmx_endpoint_execExtKey(_nativeExtKey.value, 0, args, pson_result.ptr)
-                    pson_result.value?.asResponse?.getResultOrThrow()
-                }
+                privmx_endpoint_execExtKey(_companionNativeExtKey.value, 0, args, pson_result.ptr)
+                val result =
+                    pson_result.value!!.asResponse?.getResultOrThrow() as PsonValue.PsonLong
+                ExtKey(result)
             } finally {
                 pson_free_value(args)
                 pson_free_result(pson_result.value)
@@ -57,11 +62,10 @@ actual class ExtKey private constructor() : AutoCloseable {
             val pson_result = allocPointerTo<pson_value>()
             val args = makeArgs(base58.pson)
             try {
-                ExtKey().apply {
-                    privmx_endpoint_newExtKey(_nativeExtKey.ptr)
-                    privmx_endpoint_execExtKey(_nativeExtKey.value, 1, args, pson_result.ptr)
-                    pson_result.value?.asResponse?.getResultOrThrow()
-                }
+                privmx_endpoint_execExtKey(_companionNativeExtKey.value, 1, args, pson_result.ptr)
+                val result =
+                    pson_result.value!!.asResponse?.getResultOrThrow() as PsonValue.PsonLong
+                ExtKey(result)
             } finally {
                 pson_free_value(args)
                 pson_free_result(pson_result.value)
@@ -73,11 +77,10 @@ actual class ExtKey private constructor() : AutoCloseable {
             val pson_result = allocPointerTo<pson_value>()
             val args = makeArgs()
             try {
-                ExtKey().apply {
-                    privmx_endpoint_newExtKey(_nativeExtKey.ptr)
-                    privmx_endpoint_execExtKey(_nativeExtKey.value, 2, args, pson_result.ptr)
-                    pson_result.value?.asResponse?.getResultOrThrow() as PsonValue.PsonLong
-                }
+                privmx_endpoint_execExtKey(_companionNativeExtKey.value, 2, args, pson_result.ptr)
+                val result =
+                    pson_result.value!!.asResponse?.getResultOrThrow() as PsonValue.PsonLong
+                ExtKey(result)
             } finally {
                 pson_free_value(args)
                 pson_free_result(pson_result.value)

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/ExtKey.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/ExtKey.ios.kt
@@ -93,7 +93,7 @@ actual class ExtKey private constructor() : AutoCloseable {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs(index.pson)
         try {
-            privmx_endpoint_execExtKey(_nativeExtKey.value, 3, args, pson_result.ptr)
+            privmx_endpoint_execExtKey(nativeExtKey.value, 3, args, pson_result.ptr)
             val result = pson_result.value!!.asResponse?.getResultOrThrow() as PsonValue.PsonLong
             ExtKey(result)
         } finally {
@@ -107,7 +107,7 @@ actual class ExtKey private constructor() : AutoCloseable {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs(index.pson)
         try {
-            privmx_endpoint_execExtKey(_nativeExtKey.value, 4, args, pson_result.ptr)
+            privmx_endpoint_execExtKey(nativeExtKey.value, 4, args, pson_result.ptr)
             val result = pson_result.value!!.asResponse?.getResultOrThrow() as PsonValue.PsonLong
             ExtKey(result)
         } finally {
@@ -121,7 +121,7 @@ actual class ExtKey private constructor() : AutoCloseable {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs()
         try {
-            privmx_endpoint_execExtKey(_nativeExtKey.value, 5, args, pson_result.ptr)
+            privmx_endpoint_execExtKey(nativeExtKey.value, 5, args, pson_result.ptr)
             pson_result.value!!.asResponse
                 ?.getResultOrThrow()
                 ?.typedValue()!!
@@ -136,7 +136,7 @@ actual class ExtKey private constructor() : AutoCloseable {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs()
         try {
-            privmx_endpoint_execExtKey(_nativeExtKey.value, 6, args, pson_result.ptr)
+            privmx_endpoint_execExtKey(nativeExtKey.value, 6, args, pson_result.ptr)
             pson_result.value!!.asResponse
                 ?.getResultOrThrow()
                 ?.typedValue()!!
@@ -151,7 +151,7 @@ actual class ExtKey private constructor() : AutoCloseable {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs()
         try {
-            privmx_endpoint_execExtKey(_nativeExtKey.value, 7, args, pson_result.ptr)
+            privmx_endpoint_execExtKey(nativeExtKey.value, 7, args, pson_result.ptr)
             pson_result.value!!.asResponse
                 ?.getResultOrThrow()
                 ?.typedValue()!!
@@ -166,7 +166,7 @@ actual class ExtKey private constructor() : AutoCloseable {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs()
         try {
-            privmx_endpoint_execExtKey(_nativeExtKey.value, 8, args, pson_result.ptr)
+            privmx_endpoint_execExtKey(nativeExtKey.value, 8, args, pson_result.ptr)
             pson_result.value!!.asResponse
                 ?.getResultOrThrow()
                 ?.typedValue()!!
@@ -181,7 +181,7 @@ actual class ExtKey private constructor() : AutoCloseable {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs()
         try {
-            privmx_endpoint_execExtKey(_nativeExtKey.value, 9, args, pson_result.ptr)
+            privmx_endpoint_execExtKey(nativeExtKey.value, 9, args, pson_result.ptr)
             pson_result.value!!.asResponse
                 ?.getResultOrThrow()
                 ?.typedValue()!!
@@ -196,7 +196,7 @@ actual class ExtKey private constructor() : AutoCloseable {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs()
         try {
-            privmx_endpoint_execExtKey(_nativeExtKey.value, 10, args, pson_result.ptr)
+            privmx_endpoint_execExtKey(nativeExtKey.value, 10, args, pson_result.ptr)
             pson_result.value!!.asResponse
                 ?.getResultOrThrow()
                 ?.typedValue()!!
@@ -211,7 +211,7 @@ actual class ExtKey private constructor() : AutoCloseable {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs()
         try {
-            privmx_endpoint_execExtKey(_nativeExtKey.value, 11, args, pson_result.ptr)
+            privmx_endpoint_execExtKey(nativeExtKey.value, 11, args, pson_result.ptr)
             pson_result.value!!.asResponse
                 ?.getResultOrThrow()
                 ?.typedValue()!!
@@ -232,7 +232,7 @@ actual class ExtKey private constructor() : AutoCloseable {
             signature.pson
         )
         try {
-            privmx_endpoint_execExtKey(_nativeExtKey.value, 12, args, pson_result.ptr)
+            privmx_endpoint_execExtKey(nativeExtKey.value, 12, args, pson_result.ptr)
             pson_result.value?.asResponse
                 ?.getResultOrThrow()
                 ?.typedValue()!!
@@ -247,7 +247,7 @@ actual class ExtKey private constructor() : AutoCloseable {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs()
         try {
-            privmx_endpoint_execExtKey(_nativeExtKey.value, 13, args, pson_result.ptr)
+            privmx_endpoint_execExtKey(nativeExtKey.value, 13, args, pson_result.ptr)
             pson_result.value!!.asResponse
                 ?.getResultOrThrow()
                 ?.typedValue()!!

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersFromPson.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersFromPson.kt
@@ -11,7 +11,7 @@
 
 package com.simplito.kotlin.privmx_endpoint.utils
 
-import com.simplito.java.privmx_endpoint.model.BIP39
+import com.simplito.kotlin.privmx_endpoint.model.BIP39
 import com.simplito.kotlin.privmx_endpoint.model.BridgeIdentity
 import com.simplito.kotlin.privmx_endpoint.model.ContainerPolicy
 import com.simplito.kotlin.privmx_endpoint.model.Context

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.jvm.kt
@@ -16,7 +16,7 @@ import com.simplito.kotlin.privmx_endpoint.model.Context
 import com.simplito.kotlin.privmx_endpoint.model.PKIVerificationOptions
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.UserInfo
-import com.simplito.kotlin.privmx_endpoint.model.UserVerifierInterface
+import com.simplito.kotlin.privmx_endpoint.modules.core.UserVerifierInterface
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.jvm.kt
@@ -87,8 +87,12 @@ actual class Connection private constructor(
      * Gets the ID of the current connection.
      *
      * @return ID of the connection
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is not connected.
      */
-    actual fun getConnectionId() = this.connectionId
+    @Throws(java.lang.IllegalStateException::class, PrivmxException::class, NativeException::class)
+    actual external fun getConnectionId(): Long?
 
     /**
      * If there is an active connection then it

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/core/Connection.jvm.kt
@@ -25,7 +25,6 @@ import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
  */
 actual class Connection private constructor(
     private val api: Long?,
-    private val connectionId: Long?
 ) : AutoCloseable {
     actual companion object {
         init {

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.jvm.kt
@@ -150,7 +150,7 @@ actual class CryptoApi : AutoCloseable {
      */
     @JvmOverloads
     @Throws(PrivmxException::class, NativeException::class)
-    actual external fun generateBip39(strength: Long?, password: String): BIP39
+    actual external fun generateBip39(strength: Long, password: String): BIP39
 
     /**
      * Generates ECC key using BIP-39 mnemonic.

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/CryptoApi.jvm.kt
@@ -10,7 +10,7 @@
 //
 package com.simplito.kotlin.privmx_endpoint.modules.crypto
 
-import com.simplito.java.privmx_endpoint.model.BIP39
+import com.simplito.kotlin.privmx_endpoint.model.BIP39
 import com.simplito.kotlin.privmx_endpoint.LibLoader
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/ExtKey.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/crypto/ExtKey.jvm.kt
@@ -9,9 +9,9 @@ import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
  */
 actual class ExtKey : AutoCloseable {
 
-    private val key: Long
+    private val key: Long?
 
-    private constructor(key: Long) {
+    private constructor(key: Long?) {
         this.key = key
     }
 


### PR DESCRIPTION
## Description
### PrivMX Endpoint
#### REFACTOR
* Change BIP39 class package from `com.simplito.java...` to `com.simplito.kotlin...`
* Fix `strength` argument type from `Long?` to `Long` in `CryptoApi.generateBip39` method
* Fix `key` argument type from `Long` to `Long?` in private `ExtKey` constructor
* Move `UserVerifierInterface` interface from `model` to `modules/core` package
* Reduce memory overhead during creating ExtKey in iOS.
* Remove private `connectionId` constructor param and property on JVM target.
* Now `getConnectionId` method call native equivalent method, so after call `close` method `getConnectionId` returns `IllegalStateException` on JVM target.
* Calling ExtKey methods after closing the object will throw `IllegalStateException`.
