### PR TITLE
feat(privmx-endpoint): implement kvdb api

### DIFF
--- a/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/events/EventType.kt
+++ b/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/events/EventType.kt
@@ -10,9 +10,14 @@
 //
 package com.simplito.kotlin.privmx_endpoint_extra.events
 
+import com.simplito.java.privmx_endpoint.model.events.KvdbDeletedEntryEventData
+import com.simplito.java.privmx_endpoint.model.events.KvdbDeletedEventData
+import com.simplito.java.privmx_endpoint.model.events.KvdbStatsEventData
 import com.simplito.kotlin.privmx_endpoint.model.File
 import com.simplito.kotlin.privmx_endpoint.model.Inbox
 import com.simplito.kotlin.privmx_endpoint.model.InboxEntry
+import com.simplito.kotlin.privmx_endpoint.model.Kvdb
+import com.simplito.kotlin.privmx_endpoint.model.KvdbEntry
 import com.simplito.kotlin.privmx_endpoint.model.Message
 import com.simplito.kotlin.privmx_endpoint.model.Store
 import com.simplito.kotlin.privmx_endpoint.model.Thread
@@ -189,4 +194,48 @@ sealed class EventType<T: Any>(
      */
     data class ContextCustomEvent(val contextId: String, val channelName: String) :
         EventType<ContextCustomEventData>("context/$contextId/$channelName", "contextCustom")
+
+    /**
+     * Predefined event type to catch created Kvdb events.
+     */
+    data object KvdbCreatedEvent : EventType<Kvdb>("kvdb", "kvdbCreated")
+
+    /**
+     * Predefined event type to catch updated Kvdb events.
+     */
+    data object KvdbUpdatedEvent : EventType<Kvdb>("kvdb", "kvdbUpdated")
+
+    /**
+     * Predefined event type to catch updated Kvdb stats events.
+     */
+    data object KvdbStatsEvent : EventType<KvdbStatsEventData>("kvdb", "kvdbStatsChanged")
+
+    /**
+     * Predefined event type to catch deleted Kvdb events.
+     */
+    data object KvdbDeletedEvent : EventType<KvdbDeletedEventData>("kvdb", "kvdbDeleted")
+
+    /**
+     * Predefined event type to catch created KvdbEntry events.
+     *
+     * @property kvdbId ID of the Kvdb to observe
+     */
+    data class KvdbNewEntry(val kvdbId: String) :
+        EventType<KvdbEntry>("kvdb/$kvdbId/entries", "kvdbNewEntry")
+
+    /**
+     * Predefined event type to catch updated KvdbEntry events.
+     *
+     * @property kvdbId ID of the Kvdb to observe
+     */
+    data class KvdbEntryUpdatedEvent(val kvdbId: String) :
+        EventType<KvdbEntry>("kvdb/$kvdbId/entries", "kvdbEntryUpdated")
+
+    /**
+     * Predefined event type to catch deleted KvdbEntry events.
+     *
+     * @property kvdbId ID of the Kvdb to observe
+     */
+    data class KvdbEntryDeletedEvent(val kvdbId: String) :
+        EventType<KvdbDeletedEntryEventData>("kvdb/$kvdbId/entries", "kvdbEntryDeleted")
 }

--- a/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/events/EventType.kt
+++ b/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/events/EventType.kt
@@ -196,45 +196,44 @@ sealed class EventType<T: Any>(
         EventType<ContextCustomEventData>("context/$contextId/$channelName", "contextCustom")
 
     /**
-     * Predefined event type to catch created Kvdb events.
+     * Predefined event type to catch created KVDB events.
      */
     data object KvdbCreatedEvent : EventType<Kvdb>("kvdb", "kvdbCreated")
 
     /**
-     * Predefined event type to catch updated Kvdb events.
+     * Predefined event type to catch updated KVDB events.
      */
     data object KvdbUpdatedEvent : EventType<Kvdb>("kvdb", "kvdbUpdated")
 
     /**
-     * Predefined event type to catch updated Kvdb stats events.
+     * Predefined event type to catch updated KVDB stats events.
      */
     data object KvdbStatsEvent : EventType<KvdbStatsEventData>("kvdb", "kvdbStatsChanged")
 
     /**
-     * Predefined event type to catch deleted Kvdb events.
+     * Predefined event type to catch deleted KVDB events.
      */
     data object KvdbDeletedEvent : EventType<KvdbDeletedEventData>("kvdb", "kvdbDeleted")
 
     /**
-     * Predefined event type to catch created KvdbEntry events.
-     *
-     * @property kvdbId ID of the Kvdb to observe
+     * Type to register on created KVDB entries events.
+     * @property kvdbId ID of the KVDB to observe
      */
     data class KvdbNewEntry(val kvdbId: String) :
         EventType<KvdbEntry>("kvdb/$kvdbId/entries", "kvdbNewEntry")
 
     /**
-     * Predefined event type to catch updated KvdbEntry events.
+     * Type to register on updated KVDB entries events.
      *
-     * @property kvdbId ID of the Kvdb to observe
+     * @property kvdbId ID of the KVDB to observe
      */
     data class KvdbEntryUpdatedEvent(val kvdbId: String) :
         EventType<KvdbEntry>("kvdb/$kvdbId/entries", "kvdbEntryUpdated")
 
     /**
-     * Predefined event type to catch deleted KvdbEntry events.
+     * Type to register on deleted KVDB entries events.
      *
-     * @property kvdbId ID of the Kvdb to observe
+     * @property kvdbId ID of the KVDB to observe
      */
     data class KvdbEntryDeletedEvent(val kvdbId: String) :
         EventType<KvdbDeletedEntryEventData>("kvdb/$kvdbId/entries", "kvdbEntryDeleted")

--- a/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/lib/BasicPrivmxEndpoint.kt
+++ b/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/lib/BasicPrivmxEndpoint.kt
@@ -16,6 +16,7 @@ import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
 import com.simplito.kotlin.privmx_endpoint.modules.crypto.CryptoApi
 import com.simplito.kotlin.privmx_endpoint.modules.event.EventApi
 import com.simplito.kotlin.privmx_endpoint.modules.inbox.InboxApi
+import com.simplito.kotlin.privmx_endpoint.modules.kvdb.KvdbApi
 import com.simplito.kotlin.privmx_endpoint.modules.store.StoreApi
 import com.simplito.kotlin.privmx_endpoint.modules.thread.ThreadApi
 import com.simplito.kotlin.privmx_endpoint_extra.model.Modules
@@ -79,6 +80,12 @@ constructor(
         if (enableModule.contains(Modules.CUSTOM_EVENT)) EventApi(connection) else null
 
     /**
+     * Reference to Kvdb module.
+     */
+    val kvdbApi: KvdbApi? =
+        if (enableModule.contains(Modules.KVDB)) KvdbApi(connection) else null
+
+    /**
      * Disconnects from PrivMX Bridge and frees memory.
      *
      * @throws Exception when instance is currently closed
@@ -88,6 +95,7 @@ constructor(
         storeApi?.close()
         inboxApi?.close()
         eventApi?.close()
+        kvdbApi?.close()
         connection.close()
     }
 }

--- a/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/lib/BasicPrivmxEndpoint.kt
+++ b/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/lib/BasicPrivmxEndpoint.kt
@@ -80,7 +80,7 @@ constructor(
         if (enableModule.contains(Modules.CUSTOM_EVENT)) EventApi(connection) else null
 
     /**
-     * Reference to Kvdb module.
+     * Reference to KVDB module.
      */
     val kvdbApi: KvdbApi? =
         if (enableModule.contains(Modules.KVDB)) KvdbApi(connection) else null

--- a/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/lib/PrivmxEndpoint.kt
+++ b/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/lib/PrivmxEndpoint.kt
@@ -155,6 +155,18 @@ constructor(
                 }
             }
         }
+
+        if (channel.module.startsWith("kvdb") && kvdbApi != null) {
+            if (channel.type != null && channel.type == "entries") {
+                if (channel.instanceId != null) {
+                    kvdbApi.subscribeForEntryEvents(channel.instanceId)
+                } else {
+                    println("No kvdbId to subscribeChannel: " + channelStr)
+                }
+                return
+            }
+            kvdbApi.subscribeForKvdbEvents()
+        }
     }
 
     private fun unsubscribeChannel(channelStr: String) {
@@ -209,6 +221,18 @@ constructor(
                     println("No contextId to unsubscribeChannel: " + channelStr)
                 }
             }
+        }
+
+        if (channel.module.startsWith("kvdb") && kvdbApi != null) {
+            if (channel.type != null && channel.type == "entries") {
+                if (channel.instanceId != null) {
+                    kvdbApi.unsubscribeFromEntryEvents(channel.instanceId)
+                } else {
+                    println("No kvdbId to unsubscribeChannel: " + channelStr)
+                }
+                return
+            }
+            kvdbApi.unsubscribeFromKvdbEvents()
         }
     }
 

--- a/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/model/Modules.kt
+++ b/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/model/Modules.kt
@@ -33,4 +33,9 @@ enum class Modules {
      * CustomEvent module case.
      */
     CUSTOM_EVENT,
+
+    /**
+     * Kvdb module case.
+     */
+    KVDB,
 }

--- a/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/model/Modules.kt
+++ b/privmx-endpoint-extra/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint_extra/model/Modules.kt
@@ -35,7 +35,7 @@ enum class Modules {
     CUSTOM_EVENT,
 
     /**
-     * Kvdb module case.
+     * KVDB module case.
      */
     KVDB,
 }

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/Kvdb.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/Kvdb.kt
@@ -19,9 +19,6 @@ package com.simplito.kotlin.privmx_endpoint.model
  * @property policy Kvdb's policies
  * @property statusCode Retrieval and decryption status code
  * @property schemaVersion Version of the Kvdb data structure and how it is encoded/encrypted
- *
- * @category kvdb
- * @group Kvdb
  */
 data class Kvdb(
     val contextId: String,

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/Kvdb.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/Kvdb.kt
@@ -1,0 +1,89 @@
+package com.simplito.kotlin.privmx_endpoint.model
+
+/**
+ * Holds all available information about a Kvdb.
+ *
+ * @property contextId ID of the Context
+ * @property kvdbId ID of the Kvdb
+ * @property createDate Kvdb creation timestamp
+ * @property creator ID of user who created the Kvdb
+ * @property lastModificationDate Kvdb last modification timestamp
+ * @property lastModifier ID of the user who last modified the Kvdb
+ * @property users List of users (their IDs) with access to the Kvdb
+ * @property managers List of users (their IDs) with management rights
+ * @property version Version number (changes on updates)
+ * @property publicMeta Kvdb's public metadata
+ * @property privateMeta Kvdb's private metadata
+ * @property entries Total number of entries in the Kvdb
+ * @property lastEntryDate Timestamp of the last added entry
+ * @property policy Kvdb's policies
+ * @property statusCode Retrieval and decryption status code
+ * @property schemaVersion Version of the Kvdb data structure and how it is encoded/encrypted
+ *
+ * @category kvdb
+ * @group Kvdb
+ */
+data class Kvdb(
+    val contextId: String,
+    val kvdbId: String,
+    val createDate: Long?,
+    val creator: String,
+    val lastModificationDate: Long?,
+    val lastModifier: String,
+    val users: List<String>,
+    val managers: List<String>,
+    val version: Long?,
+    val publicMeta: ByteArray,
+    val privateMeta: ByteArray,
+    val entries: Long?,
+    val lastEntryDate: Long?,
+    val policy: ContainerPolicy?,
+    val statusCode: Long?,
+    val schemaVersion: Long?
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as Kvdb
+
+        if (createDate != other.createDate) return false
+        if (lastModificationDate != other.lastModificationDate) return false
+        if (version != other.version) return false
+        if (entries != other.entries) return false
+        if (lastEntryDate != other.lastEntryDate) return false
+        if (statusCode != other.statusCode) return false
+        if (schemaVersion != other.schemaVersion) return false
+        if (contextId != other.contextId) return false
+        if (kvdbId != other.kvdbId) return false
+        if (creator != other.creator) return false
+        if (lastModifier != other.lastModifier) return false
+        if (users != other.users) return false
+        if (managers != other.managers) return false
+        if (!publicMeta.contentEquals(other.publicMeta)) return false
+        if (!privateMeta.contentEquals(other.privateMeta)) return false
+        if (policy != other.policy) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = createDate?.hashCode() ?: 0
+        result = 31 * result + (lastModificationDate?.hashCode() ?: 0)
+        result = 31 * result + (version?.hashCode() ?: 0)
+        result = 31 * result + (entries?.hashCode() ?: 0)
+        result = 31 * result + (lastEntryDate?.hashCode() ?: 0)
+        result = 31 * result + (statusCode?.hashCode() ?: 0)
+        result = 31 * result + (schemaVersion?.hashCode() ?: 0)
+        result = 31 * result + contextId.hashCode()
+        result = 31 * result + kvdbId.hashCode()
+        result = 31 * result + creator.hashCode()
+        result = 31 * result + lastModifier.hashCode()
+        result = 31 * result + users.hashCode()
+        result = 31 * result + managers.hashCode()
+        result = 31 * result + publicMeta.contentHashCode()
+        result = 31 * result + privateMeta.contentHashCode()
+        result = 31 * result + (policy?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/Kvdb.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/Kvdb.kt
@@ -1,24 +1,24 @@
 package com.simplito.kotlin.privmx_endpoint.model
 
 /**
- * Holds all available information about a Kvdb.
+ * Holds all available information about a KVDB.
  *
  * @property contextId ID of the Context
- * @property kvdbId ID of the Kvdb
- * @property createDate Kvdb creation timestamp
- * @property creator ID of user who created the Kvdb
- * @property lastModificationDate Kvdb last modification timestamp
- * @property lastModifier ID of the user who last modified the Kvdb
- * @property users List of users (their IDs) with access to the Kvdb
+ * @property kvdbId ID of the KVDB
+ * @property createDate KVDB creation timestamp
+ * @property creator ID of user who created the KVDB
+ * @property lastModificationDate KVDB last modification timestamp
+ * @property lastModifier ID of the user who last modified the KVDB
+ * @property users List of users (their IDs) with access to the KVDB
  * @property managers List of users (their IDs) with management rights
  * @property version Version number (changes on updates)
- * @property publicMeta Kvdb's public metadata
- * @property privateMeta Kvdb's private metadata
- * @property entries Total number of entries in the Kvdb
+ * @property publicMeta KVDB's public metadata
+ * @property privateMeta KVDB's private metadata
+ * @property entries Total number of entries in the KVDB
  * @property lastEntryDate Timestamp of the last added entry
- * @property policy Kvdb's policies
+ * @property policy KVDB's policies
  * @property statusCode Retrieval and decryption status code
- * @property schemaVersion Version of the Kvdb data structure and how it is encoded/encrypted
+ * @property schemaVersion Version of the KVDB data structure and how it is encoded/encrypted
  */
 data class Kvdb(
     val contextId: String,

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/KvdbEntry.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/KvdbEntry.kt
@@ -11,9 +11,6 @@ package com.simplito.kotlin.privmx_endpoint.model
  * @property version Version number (changes on every on existing item)
  * @property statusCode Retrieval and decryption status code
  * @property schemaVersion Version of the Entry data structure and how it is encoded/encrypted
- *
- * @category kvdb
- * @group Kvdb
  */
 class KvdbEntry(
     val info: ServerKvdbEntryInfo,

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/KvdbEntry.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/KvdbEntry.kt
@@ -1,0 +1,27 @@
+package com.simplito.kotlin.privmx_endpoint.model
+
+/**
+ * Holds all available information about a Entry.
+ *
+ * @property info Entry information created by server
+ * @property publicMeta Entry public metadata
+ * @property privateMeta Entry private metadata
+ * @property data Entry data
+ * @property authorPubKey Public key of an author of the entry
+ * @property version Version number (changes on every on existing item)
+ * @property statusCode Retrieval and decryption status code
+ * @property schemaVersion Version of the Entry data structure and how it is encoded/encrypted
+ *
+ * @category kvdb
+ * @group Kvdb
+ */
+class KvdbEntry(
+    val info: ServerKvdbEntryInfo,
+    val publicMeta: ByteArray,
+    val privateMeta: ByteArray,
+    val data: ByteArray,
+    val authorPubKey: String,
+    val version: Long?,
+    val statusCode: Long?,
+    val schemaVersion: Long?
+)

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/KvdbEntry.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/KvdbEntry.kt
@@ -1,7 +1,7 @@
 package com.simplito.kotlin.privmx_endpoint.model
 
 /**
- * Holds all available information about a Entry.
+ * Holds all available information about an Entry.
  *
  * @property info Entry information created by server
  * @property publicMeta Entry public metadata

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/ServerKvdbEntryInfo.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/ServerKvdbEntryInfo.kt
@@ -7,9 +7,6 @@ package com.simplito.kotlin.privmx_endpoint.model
  * @param key Kvdb entry's key
  * @param createDate Entry's creation timestamp
  * @param author ID of the user who created the entry
- *
- * @category kvdb
- * @group Kvdb
  */
 class ServerKvdbEntryInfo(
     val kvdbId: String,

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/ServerKvdbEntryInfo.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/ServerKvdbEntryInfo.kt
@@ -1,0 +1,19 @@
+package com.simplito.kotlin.privmx_endpoint.model
+
+/**
+ * Holds Kvdb entry's information created by the server.
+ *
+ * @param kvdbId ID of the Kvdb
+ * @param key Kvdb entry's key
+ * @param createDate Entry's creation timestamp
+ * @param author ID of the user who created the entry
+ *
+ * @category kvdb
+ * @group Kvdb
+ */
+class ServerKvdbEntryInfo(
+    val kvdbId: String,
+    val key: String,
+    val createDate: Long?,
+    val author: String
+) 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/ServerKvdbEntryInfo.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/ServerKvdbEntryInfo.kt
@@ -1,10 +1,10 @@
 package com.simplito.kotlin.privmx_endpoint.model
 
 /**
- * Holds Kvdb entry's information created by the server.
+ * Holds KVDB entry's information created by the server.
  *
- * @param kvdbId ID of the Kvdb
- * @param key Kvdb entry's key
+ * @param kvdbId ID of the KVDB
+ * @param key KVDB entry's key
  * @param createDate Entry's creation timestamp
  * @param author ID of the user who created the entry
  */

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbDeletedEntryEventData.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbDeletedEntryEventData.kt
@@ -1,0 +1,12 @@
+package com.simplito.java.privmx_endpoint.model.events
+
+/**
+ * Holds information of `KvdbDeletedEntryEvent`.
+ *
+ * @property kvdbId Kvdb ID
+ * @property kvdbEntryKey Key of deleted Entry
+ */
+data class KvdbDeletedEntryEventData(
+    val kvdbId: String,
+    val kvdbEntryKey: String
+) 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbDeletedEntryEventData.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbDeletedEntryEventData.kt
@@ -1,7 +1,7 @@
 package com.simplito.java.privmx_endpoint.model.events
 
 /**
- * Holds information of `KvdbDeletedEntryEvent`.
+ * Holds data of event that arrives when KVDB entry is deleted.
  *
  * @property kvdbId KVDB ID
  * @property kvdbEntryKey Key of deleted Entry
@@ -9,4 +9,4 @@ package com.simplito.java.privmx_endpoint.model.events
 data class KvdbDeletedEntryEventData(
     val kvdbId: String,
     val kvdbEntryKey: String
-) 
+)

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbDeletedEntryEventData.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbDeletedEntryEventData.kt
@@ -3,7 +3,7 @@ package com.simplito.java.privmx_endpoint.model.events
 /**
  * Holds information of `KvdbDeletedEntryEvent`.
  *
- * @property kvdbId Kvdb ID
+ * @property kvdbId KVDB ID
  * @property kvdbEntryKey Key of deleted Entry
  */
 data class KvdbDeletedEntryEventData(

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbDeletedEventData.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbDeletedEventData.kt
@@ -3,7 +3,7 @@ package com.simplito.java.privmx_endpoint.model.events
 /**
  * Holds information of `KvdbDeletedEvent`.
  *
- * @property kvdbId Kvdb ID
+ * @property kvdbId KVDB ID
  */
 data class KvdbDeletedEventData(
     val kvdbId: String

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbDeletedEventData.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbDeletedEventData.kt
@@ -1,0 +1,10 @@
+package com.simplito.java.privmx_endpoint.model.events
+
+/**
+ * Holds information of `KvdbDeletedEvent`.
+ *
+ * @property kvdbId Kvdb ID
+ */
+data class KvdbDeletedEventData(
+    val kvdbId: String
+) 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbDeletedEventData.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbDeletedEventData.kt
@@ -1,7 +1,7 @@
 package com.simplito.java.privmx_endpoint.model.events
 
 /**
- * Holds information of `KvdbDeletedEvent`.
+ * Holds data of event that arrives when KVDB is deleted.
  *
  * @property kvdbId KVDB ID
  */

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbStatsEventData.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbStatsEventData.kt
@@ -1,11 +1,11 @@
 package com.simplito.java.privmx_endpoint.model.events
 
 /**
- * Holds Kvdb statistical data.
+ * Holds KVDB statistical data.
  *
- * @property kvdbId Kvdb ID
- * @property lastEntryDate Timestamp of the most recent Kvdb item
- * @property entries  Updated number of entries in the Kvdb
+ * @property kvdbId KVDB ID
+ * @property lastEntryDate Timestamp of the most recent KVDB item
+ * @property entries  Updated number of entries in the KVDB
  */
 data class KvdbStatsEventData(
     val kvdbId: String,

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbStatsEventData.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbStatsEventData.kt
@@ -1,0 +1,14 @@
+package com.simplito.java.privmx_endpoint.model.events
+
+/**
+ * Holds Kvdb statistical data.
+ *
+ * @property kvdbId Kvdb ID
+ * @property lastEntryDate Timestamp of the most recent Kvdb item
+ * @property entries  Updated number of entries in the Kvdb
+ */
+data class KvdbStatsEventData(
+    val kvdbId: String,
+    val lastEntryDate: Long?,
+    val entries: Long?
+) 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbStatsEventData.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/KvdbStatsEventData.kt
@@ -1,7 +1,7 @@
 package com.simplito.java.privmx_endpoint.model.events
 
 /**
- * Holds KVDB statistical data.
+ * Holds data of event that arrives when KVDB stats change.
  *
  * @property kvdbId KVDB ID
  * @property lastEntryDate Timestamp of the most recent KVDB item

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
@@ -1,8 +1,8 @@
 package com.simplito.kotlin.privmx_endpoint.modules.kvdb
 
+import com.simplito.kotlin.privmx_endpoint.model.ContainerPolicy
 import com.simplito.kotlin.privmx_endpoint.model.Kvdb
 import com.simplito.kotlin.privmx_endpoint.model.KvdbEntry
-import com.simplito.kotlin.privmx_endpoint.model.ContainerPolicy
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
@@ -11,8 +11,6 @@ import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
 
 /**
  * Manages PrivMX Bridge  Kvdbs and their messages.
- *
- * @category kvdb
  */
 expect class KvdbApi(connection: Connection) : AutoCloseable {
 
@@ -138,6 +136,22 @@ expect class KvdbApi(connection: Connection) : AutoCloseable {
     ): KvdbEntry
 
     /**
+     * Check whether the KVDB entry exists.
+     *
+     * @param kvdbId KVDB ID of the KVDB entry to check
+     * @param key    key of the KVDB entry to check
+     * @return 'true' if the KVDB has an entry with given key, 'false' otherwise
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun hasEntry(
+        kvdbId: String,
+        key: String
+    ): Boolean
+
+    /**
      * Gets a list of KVDB entries keys from a KVDB.
      *
      * @param kvdbId      ID of the KVDB to list KVDB entries from
@@ -209,7 +223,7 @@ expect class KvdbApi(connection: Connection) : AutoCloseable {
         publicMeta: ByteArray,
         privateMeta: ByteArray,
         data: ByteArray,
-        version: Long
+        version: Long = 0
     )
 
     /**
@@ -284,8 +298,6 @@ expect class KvdbApi(connection: Connection) : AutoCloseable {
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
     fun unsubscribeFromEntryEvents(kvdbId: String)
-
-    //TODO: Implement "hasEntry"
 
     /**
      * Frees memory.

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
@@ -66,8 +66,8 @@ expect class KvdbApi(connection: Connection) : AutoCloseable {
         privateMeta: ByteArray,
         version: Long,
         force: Boolean,
-        forceGenerateNewKey: Boolean,
-        policies: ContainerPolicy?
+        forceGenerateNewKey: Boolean = false,
+        policies: ContainerPolicy? = null
     )
 
 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
@@ -10,7 +10,7 @@ import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
 
 /**
- * Manages PrivMX Bridge  KVDBs and their messages.
+ * Manages PrivMX Bridge KVDBs and their entries.
  */
 expect class KvdbApi(connection: Connection) : AutoCloseable {
 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
@@ -1,0 +1,296 @@
+package com.simplito.kotlin.privmx_endpoint.modules.kvdb
+
+import com.simplito.kotlin.privmx_endpoint.model.Kvdb
+import com.simplito.kotlin.privmx_endpoint.model.KvdbEntry
+import com.simplito.kotlin.privmx_endpoint.model.ContainerPolicy
+import com.simplito.kotlin.privmx_endpoint.model.PagingList
+import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
+import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
+import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
+
+/**
+ * Manages PrivMX Bridge  Kvdbs and their messages.
+ *
+ * @category kvdb
+ */
+expect class KvdbApi(connection: Connection) : AutoCloseable {
+
+    /**
+     * Creates a new KVDB in given Context.
+     *
+     * @param contextId   ID of the Context to create the KVDB in
+     * @param users       list of [UserWithPubKey] which indicates who will have access to the created KVDB
+     * @param managers    list of [UserWithPubKey] which indicates who will have access (and management rights) to the created KVDB
+     * @param publicMeta  public (unencrypted) metadata
+     * @param privateMeta private (encrypted) metadata
+     * @param policies    KVDB's policies
+     * @return ID of the created KVDB
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun createKvdb(
+        contextId: String,
+        users: List<UserWithPubKey>,
+        managers: List<UserWithPubKey>,
+        publicMeta: ByteArray,
+        privateMeta: ByteArray,
+        policies: ContainerPolicy? = null
+    ): String
+
+
+    /**
+     * Updates an existing KVDB.
+     *
+     * @param kvdbId              ID of the KVDB to update
+     * @param users               list of [UserWithPubKey] which indicates who will have access to the created KVDB
+     * @param managers            list of [UserWithPubKey] which indicates who will have access (and management rights) to the created KVDB
+     * @param publicMeta          public (unencrypted) metadata
+     * @param privateMeta         private (encrypted) metadata
+     * @param version             current version of the updated KVDB
+     * @param force               force update (without checking version)
+     * @param forceGenerateNewKey force to regenerate a key for the KVDB
+     * @param policies            KVDB's policies
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun updateKvdb(
+        kvdbId: String,
+        users: List<UserWithPubKey>,
+        managers: List<UserWithPubKey>,
+        publicMeta: ByteArray,
+        privateMeta: ByteArray,
+        version: Long,
+        force: Boolean,
+        forceGenerateNewKey: Boolean,
+        policies: ContainerPolicy?
+    )
+
+
+    /**
+     * Deletes a KVDB by given KVDB ID.
+     *
+     * @param kvdbId ID of the KVDB to delete
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun deleteKvdb(kvdbId: String)
+
+    /**
+     * Gets a KVDB by given KVDB ID.
+     *
+     * @param kvdbId ID of KVDB to get
+     * @return object containing info about the KVDB
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun getKvdb(kvdbId: String): Kvdb
+
+    /**
+     * Gets a list of Kvdbs in given Context.
+     *
+     * @param contextId   ID of the Context to get the Kvdbs from
+     * @param skip        skip number of elements to skip from result
+     * @param limit       limit of elements to return for query
+     * @param sortOrder   order of elements in result ("asc" for ascending, "desc" for descending)
+     * @param lastId      ID of the element from which query results should start
+     * @param queryAsJson stringified JSON object with a custom field to filter result
+     * @param sortBy      field by elements are sorted in result
+     * @return list of Kvdbs
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun listKvdbs(
+        contextId: String,
+        skip: Long,
+        limit: Long,
+        sortOrder: String,
+        lastId: String? = null,
+        queryAsJson: String? = null,
+        sortBy: String? = null
+    ): PagingList<Kvdb>
+
+
+    /**
+     * Gets a KVDB entry by given KVDB entry key and KVDB ID.
+     *
+     * @param kvdbId KVDB ID of the KVDB entry to get
+     * @param key    key of the KVDB entry to get
+     * @return object containing the KVDB entry
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun getEntry(
+        kvdbId: String,
+        key: String
+    ): KvdbEntry
+
+    /**
+     * Gets a list of KVDB entries keys from a KVDB.
+     *
+     * @param kvdbId      ID of the KVDB to list KVDB entries from
+     * @param skip        skip number of elements to skip from result
+     * @param limit       limit of elements to return for query
+     * @param sortOrder   order of elements in result ("asc" for ascending, "desc" for descending)
+     * @param lastId      ID of the element from which query results should start
+     * @param queryAsJson stringified JSON object with a custom field to filter result
+     * @param sortBy      field by elements are sorted in result
+     * @return list of KVDB entries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun listEntriesKeys(
+        kvdbId: String,
+        skip: Long,
+        limit: Long,
+        sortOrder: String,
+        lastId: String? = null,
+        queryAsJson: String? = null,
+        sortBy: String? = null
+    ): PagingList<String>
+
+    /**
+     * Gets a list of KVDB entries from a KVDB.
+     *
+     * @param kvdbId      ID of the KVDB to list KVDB entries from
+     * @param skip        skip number of elements to skip from result
+     * @param limit       limit of elements to return for query
+     * @param sortOrder   order of elements in result ("asc" for ascending, "desc" for descending)
+     * @param lastId      ID of the element from which query results should start
+     * @param queryAsJson stringified JSON object with a custom field to filter result
+     * @param sortBy      field by elements are sorted in result
+     * @return list of KVDB entries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun listEntries(
+        kvdbId: String,
+        skip: Long,
+        limit: Long,
+        sortOrder: String,
+        lastId: String? = null,
+        queryAsJson: String? = null,
+        sortBy: String? = null
+    ): PagingList<KvdbEntry>
+
+
+    /**
+     * Sets a KVDB entry in the given KVDB.
+     *
+     * @param kvdbId      ID of the KVDB to set the entry to
+     * @param key         KVDB entry key
+     * @param publicMeta  public KVDB entry metadata
+     * @param privateMeta private KVDB entry metadata
+     * @param data        content of the KVDB entry
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun setEntry(
+        kvdbId: String,
+        key: String,
+        publicMeta: ByteArray,
+        privateMeta: ByteArray,
+        data: ByteArray,
+        version: Long
+    )
+
+    /**
+     * Deletes a KVDB entry by given KVDB entry ID.
+     *
+     * @param kvdbId KVDB ID of the KVDB entry to delete
+     * @param key    key of the KVDB entry to delete
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun deleteEntry(
+        kvdbId: String,
+        key: String
+    )
+
+    /**
+     * Deletes KVDB entries by given KVDB IDs and the list of entry keys.
+     *
+     * @param kvdbId ID of the KVDB database to delete from
+     * @param keys   vector of the keys of the KVDB entries to delete
+     * @return map with the statuses of deletion for every key
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun deleteEntries(
+        kvdbId: String,
+        keys: List<String>
+    ): Map<String, Boolean>
+
+    /**
+     * Subscribes for the KVDB module main events.
+     *
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun subscribeForKvdbEvents()
+
+    /**
+     * Unsubscribes from the KVDB module main events.
+     *
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun unsubscribeFromKvdbEvents()
+
+    /**
+     * Subscribes for events in given KVDB.
+     *
+     * @param kvdbId ID of the KVDB to subscribe
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun subscribeForEntryEvents(kvdbId: String)
+
+    /**
+     * Unsubscribes from events in given KVDB.
+     *
+     * @param kvdbId ID of the KVDB to unsubscribe
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun unsubscribeFromEntryEvents(kvdbId: String)
+
+    //TODO: Implement "hasEntry"
+
+    /**
+     * Frees memory.
+     *
+     * @throws Exception when instance is currently closed.
+     */
+    override fun close()
+}

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
@@ -10,7 +10,7 @@ import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
 
 /**
- * Manages PrivMX Bridge  Kvdbs and their messages.
+ * Manages PrivMX Bridge  KVDBs and their messages.
  */
 expect class KvdbApi(connection: Connection) : AutoCloseable {
 
@@ -93,16 +93,16 @@ expect class KvdbApi(connection: Connection) : AutoCloseable {
     fun getKvdb(kvdbId: String): Kvdb
 
     /**
-     * Gets a list of Kvdbs in given Context.
+     * Gets a list of KVDBs in given Context.
      *
-     * @param contextId   ID of the Context to get the Kvdbs from
+     * @param contextId   ID of the Context to get the KVDBs from
      * @param skip        skip number of elements to skip from result
      * @param limit       limit of elements to return for query
      * @param sortOrder   order of elements in result ("asc" for ascending, "desc" for descending)
      * @param lastId      ID of the element from which query results should start
      * @param queryAsJson stringified JSON object with a custom field to filter result
      * @param sortBy      field by elements are sorted in result
-     * @return list of Kvdbs
+     * @return list of KVDBs
      * @throws IllegalStateException thrown when instance is closed.
      * @throws PrivmxException       thrown when method encounters an exception.
      * @throws NativeException       thrown when method encounters an unknown exception.

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
@@ -114,7 +114,7 @@ expect class KvdbApi(connection: Connection) : AutoCloseable {
         contextId: String,
         skip: Long,
         limit: Long,
-        sortOrder: String,
+        sortOrder: String = "desc",
         lastId: String? = null,
         queryAsJson: String? = null,
         sortBy: String? = null
@@ -157,7 +157,7 @@ expect class KvdbApi(connection: Connection) : AutoCloseable {
         kvdbId: String,
         skip: Long,
         limit: Long,
-        sortOrder: String,
+        sortOrder: String = "desc",
         lastId: String? = null,
         queryAsJson: String? = null,
         sortBy: String? = null
@@ -183,7 +183,7 @@ expect class KvdbApi(connection: Connection) : AutoCloseable {
         kvdbId: String,
         skip: Long,
         limit: Long,
-        sortOrder: String,
+        sortOrder: String = "desc",
         lastId: String? = null,
         queryAsJson: String? = null,
         sortBy: String? = null

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.ios.kt
@@ -35,7 +35,7 @@ import libprivmxendpoint.pson_free_value
 import libprivmxendpoint.pson_new_array
 
 /**
- * Manages PrivMX Bridge  Kvdbs and their messages.
+ * Manages PrivMX Bridge  KVDBs and their messages.
  */
 @OptIn(ExperimentalForeignApi::class)
 actual class KvdbApi
@@ -200,16 +200,16 @@ actual constructor(connection: Connection) : AutoCloseable {
     }
 
     /**
-     * Gets a list of Kvdbs in given Context.
+     * Gets a list of KVDBs in given Context.
      *
-     * @param contextId   ID of the Context to get the Kvdbs from
+     * @param contextId   ID of the Context to get the KVDBs from
      * @param skip        skip number of elements to skip from result
      * @param limit       limit of elements to return for query
      * @param sortOrder   order of elements in result ("asc" for ascending, "desc" for descending)
      * @param lastId      ID of the element from which query results should start
      * @param queryAsJson stringified JSON object with a custom field to filter result
      * @param sortBy      field by elements are sorted in result
-     * @return list of Kvdbs
+     * @return list of KVDBs
      * @throws IllegalStateException thrown when instance is closed.
      * @throws PrivmxException       thrown when method encounters an exception.
      * @throws NativeException       thrown when method encounters an unknown exception.

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.ios.kt
@@ -1,0 +1,584 @@
+package com.simplito.kotlin.privmx_endpoint.modules.kvdb
+
+import cnames.structs.pson_value
+import com.simplito.kotlin.privmx_endpoint.model.Kvdb
+import com.simplito.kotlin.privmx_endpoint.model.KvdbEntry
+import com.simplito.kotlin.privmx_endpoint.model.ContainerPolicy
+import com.simplito.kotlin.privmx_endpoint.model.PagingList
+import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
+import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
+import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
+import com.simplito.kotlin.privmx_endpoint.utils.KPSON_NULL
+import com.simplito.kotlin.privmx_endpoint.utils.PsonValue
+import com.simplito.kotlin.privmx_endpoint.utils.asResponse
+import com.simplito.kotlin.privmx_endpoint.utils.makeArgs
+import com.simplito.kotlin.privmx_endpoint.utils.mapOfWithNulls
+import com.simplito.kotlin.privmx_endpoint.utils.pson
+import com.simplito.kotlin.privmx_endpoint.utils.toPagingList
+import com.simplito.kotlin.privmx_endpoint.utils.toKvdb
+import com.simplito.kotlin.privmx_endpoint.utils.toKvdbEntry
+import com.simplito.kotlin.privmx_endpoint.utils.toMap
+import com.simplito.kotlin.privmx_endpoint.utils.toValuePagingList
+import com.simplito.kotlin.privmx_endpoint.utils.typedValue
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.allocPointerTo
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.nativeHeap
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import libprivmxendpoint.privmx_endpoint_execKvdbApi
+import libprivmxendpoint.privmx_endpoint_freeKvdbApi
+import libprivmxendpoint.privmx_endpoint_newKvdbApi
+import libprivmxendpoint.pson_free_result
+import libprivmxendpoint.pson_free_value
+import libprivmxendpoint.pson_new_array
+
+/**
+ * Manages PrivMX Bridge  Kvdbs and their messages.
+ *
+ * @category kvdb
+ */
+@OptIn(ExperimentalForeignApi::class)
+actual class KvdbApi
+actual constructor(connection: Connection) : AutoCloseable {
+    private val _nativeKvdbApi = nativeHeap.allocPointerTo<cnames.structs.KvdbApi>()
+    private val nativeKvdbApi
+        get() = _nativeKvdbApi.value?.let { _nativeKvdbApi }
+            ?: throw IllegalStateException("StoreApi has been closed.")
+
+    internal fun getKvdbPtr() = nativeKvdbApi.value
+
+    init {
+        privmx_endpoint_newKvdbApi(connection.getConnectionPtr(), _nativeKvdbApi.ptr)
+        memScoped {
+            val args = pson_new_array()
+            val pson_result = allocPointerTo<pson_value>()
+            try {
+                privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 0, args, pson_result.ptr)
+                pson_result.value!!.asResponse?.getResultOrThrow()
+            } finally {
+                pson_free_value(args)
+                pson_free_result(pson_result.value)
+            }
+        }
+    }
+
+    /**
+     * Creates a new KVDB in given Context.
+     *
+     * @param contextId   ID of the Context to create the KVDB in
+     * @param users       list of [UserWithPubKey] which indicates who will have access to the created KVDB
+     * @param managers    list of [UserWithPubKey] which indicates who will have access (and management rights) to the created KVDB
+     * @param publicMeta  public (unencrypted) metadata
+     * @param privateMeta private (encrypted) metadata
+     * @param policies    KVDB's policies
+     * @return ID of the created KVDB
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun createKvdb(
+        contextId: String,
+        users: List<UserWithPubKey>,
+        managers: List<UserWithPubKey>,
+        publicMeta: ByteArray,
+        privateMeta: ByteArray,
+        policies: ContainerPolicy?
+    ): String = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(
+            contextId.pson,
+            users.map { it.pson }.pson,
+            managers.map { it.pson }.pson,
+            publicMeta.pson,
+            privateMeta.pson,
+            policies?.pson ?: KPSON_NULL
+        )
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 1, args, pson_result.ptr)
+            pson_result.value?.asResponse?.getResultOrThrow()!!.typedValue()
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+
+    /**
+     * Updates an existing KVDB.
+     *
+     * @param kvdbId              ID of the KVDB to update
+     * @param users               list of [UserWithPubKey] which indicates who will have access to the created KVDB
+     * @param managers            list of [UserWithPubKey] which indicates who will have access (and management rights) to the created KVDB
+     * @param publicMeta          public (unencrypted) metadata
+     * @param privateMeta         private (encrypted) metadata
+     * @param version             current version of the updated KVDB
+     * @param force               force update (without checking version)
+     * @param forceGenerateNewKey force to regenerate a key for the KVDB
+     * @param policies            KVDB's policies
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    actual fun updateKvdb(
+        kvdbId: String,
+        users: List<UserWithPubKey>,
+        managers: List<UserWithPubKey>,
+        publicMeta: ByteArray,
+        privateMeta: ByteArray,
+        version: Long,
+        force: Boolean,
+        forceGenerateNewKey: Boolean,
+        policies: ContainerPolicy?
+    ) = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(
+            kvdbId.pson,
+            users.map { it.pson }.pson,
+            managers.map { it.pson }.pson,
+            publicMeta.pson,
+            privateMeta.pson,
+            version.pson,
+            force.pson,
+            forceGenerateNewKey.pson,
+            policies?.pson ?: KPSON_NULL
+        )
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 2, args, pson_result.ptr)
+            pson_result.value?.asResponse?.getResultOrThrow()
+            Unit
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+
+    /**
+     * Deletes a KVDB by given KVDB ID.
+     *
+     * @param kvdbId ID of the KVDB to delete
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun deleteKvdb(kvdbId: String) = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(kvdbId.pson)
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 3, args, pson_result.ptr)
+            pson_result.value?.asResponse?.getResultOrThrow()
+            Unit
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Gets a KVDB by given KVDB ID.
+     *
+     * @param kvdbId ID of KVDB to get
+     * @return object containing info about the KVDB
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun getKvdb(kvdbId: String): Kvdb = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(kvdbId.pson)
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 4, args, pson_result.ptr)
+            pson_result.value?.asResponse?.getResultOrThrow()!!.typedValue()
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Gets a list of Kvdbs in given Context.
+     *
+     * @param contextId   ID of the Context to get the Kvdbs from
+     * @param skip        skip number of elements to skip from result
+     * @param limit       limit of elements to return for query
+     * @param sortOrder   order of elements in result ("asc" for ascending, "desc" for descending)
+     * @param lastId      ID of the element from which query results should start
+     * @param queryAsJson stringified JSON object with a custom field to filter result
+     * @param sortBy      field by elements are sorted in result
+     * @return list of Kvdbs
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun listKvdbs(
+        contextId: String,
+        skip: Long,
+        limit: Long,
+        sortOrder: String,
+        lastId: String?,
+        queryAsJson: String?,
+        sortBy: String?
+    ): PagingList<Kvdb> = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(
+            contextId.pson,
+            mapOfWithNulls(
+                "skip" to skip.pson,
+                "limit" to limit.pson,
+                "sortOrder" to sortOrder.pson,
+                lastId?.let { "lastId" to lastId.pson },
+                queryAsJson?.let { "queryAsJson" to queryAsJson.pson },
+                sortBy?.let { "sortBy" to sortBy.pson }
+            ).pson
+        )
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 5, args, pson_result.ptr)
+            val pagingList =
+                pson_result.value!!.asResponse?.getResultOrThrow() as PsonValue.PsonObject
+            pagingList.toPagingList(PsonValue.PsonObject::toKvdb)
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+
+    /**
+     * Gets a KVDB entry by given KVDB entry key and KVDB ID.
+     *
+     * @param kvdbId KVDB ID of the KVDB entry to get
+     * @param key    key of the KVDB entry to get
+     * @return object containing the KVDB entry
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun getEntry(
+        kvdbId: String,
+        key: String
+    ): KvdbEntry = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(
+            kvdbId.pson,
+            key.pson
+        )
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 6, args, pson_result.ptr)
+            val result = pson_result.value!!.asResponse?.getResultOrThrow() as PsonValue.PsonObject
+            result.toKvdbEntry()
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Gets a list of KVDB entries keys from a KVDB.
+     *
+     * @param kvdbId      ID of the KVDB to list KVDB entries from
+     * @param skip        skip number of elements to skip from result
+     * @param limit       limit of elements to return for query
+     * @param sortOrder   order of elements in result ("asc" for ascending, "desc" for descending)
+     * @param lastId      ID of the element from which query results should start
+     * @param queryAsJson stringified JSON object with a custom field to filter result
+     * @param sortBy      field by elements are sorted in result
+     * @return list of KVDB entries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun listEntriesKeys(
+        kvdbId: String,
+        skip: Long,
+        limit: Long,
+        sortOrder: String,
+        lastId: String?,
+        queryAsJson: String?,
+        sortBy: String?
+    ): PagingList<String> = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(
+            kvdbId.pson,
+            mapOfWithNulls(
+                "skip" to skip.pson,
+                "limit" to limit.pson,
+                "sortOrder" to sortOrder.pson,
+                lastId?.let { "lastId" to lastId.pson },
+                queryAsJson?.let { "queryAsJson" to queryAsJson.pson },
+                sortBy?.let { "sortBy" to sortBy.pson }
+            ).pson
+        )
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 7, args, pson_result.ptr)
+            val pagingList =
+                pson_result.value!!.asResponse?.getResultOrThrow() as PsonValue.PsonObject
+            pagingList.toValuePagingList()
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Gets a list of KVDB entries from a KVDB.
+     *
+     * @param kvdbId      ID of the KVDB to list KVDB entries from
+     * @param skip        skip number of elements to skip from result
+     * @param limit       limit of elements to return for query
+     * @param sortOrder   order of elements in result ("asc" for ascending, "desc" for descending)
+     * @param lastId      ID of the element from which query results should start
+     * @param queryAsJson stringified JSON object with a custom field to filter result
+     * @param sortBy      field by elements are sorted in result
+     * @return list of KVDB entries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun listEntries(
+        kvdbId: String,
+        skip: Long,
+        limit: Long,
+        sortOrder: String,
+        lastId: String?,
+        queryAsJson: String?,
+        sortBy: String?
+    ): PagingList<KvdbEntry> = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(
+            kvdbId.pson,
+            mapOfWithNulls(
+                "skip" to skip.pson,
+                "limit" to limit.pson,
+                "sortOrder" to sortOrder.pson,
+                lastId?.let { "lastId" to lastId.pson },
+                queryAsJson?.let { "queryAsJson" to queryAsJson.pson },
+                sortBy?.let { "sortBy" to sortBy.pson }
+            ).pson
+        )
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 8, args, pson_result.ptr)
+            val pagingList =
+                pson_result.value!!.asResponse?.getResultOrThrow() as PsonValue.PsonObject
+            pagingList.toPagingList(PsonValue.PsonObject::toKvdbEntry)
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+
+    /**
+     * Sets a KVDB entry in the given KVDB.
+     *
+     * @param kvdbId      ID of the KVDB to set the entry to
+     * @param key         KVDB entry key
+     * @param publicMeta  public KVDB entry metadata
+     * @param privateMeta private KVDB entry metadata
+     * @param data        content of the KVDB entry
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun setEntry(
+        kvdbId: String,
+        key: String,
+        publicMeta: ByteArray,
+        privateMeta: ByteArray,
+        data: ByteArray,
+        version: Long
+    ) = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(
+            kvdbId.pson,
+            key.pson,
+            publicMeta.pson,
+            privateMeta.pson,
+            data.pson,
+            version.pson
+        )
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 9, args, pson_result.ptr)
+            pson_result.value!!.asResponse?.getResultOrThrow()
+            Unit
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Deletes a KVDB entry by given KVDB entry ID.
+     *
+     * @param kvdbId KVDB ID of the KVDB entry to delete
+     * @param key    key of the KVDB entry to delete
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun deleteEntry(
+        kvdbId: String,
+        key: String
+    ) = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(
+            kvdbId.pson,
+            key.pson
+        )
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 10, args, pson_result.ptr)
+            pson_result.value!!.asResponse?.getResultOrThrow()
+            Unit
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Deletes KVDB entries by given KVDB IDs and the list of entry keys.
+     *
+     * @param kvdbId ID of the KVDB database to delete from
+     * @param keys   vector of the keys of the KVDB entries to delete
+     * @return map with the statuses of deletion for every key
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun deleteEntries(
+        kvdbId: String,
+        keys: List<String>
+    ): Map<String, Boolean> = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(
+            kvdbId.pson,
+            keys.map { it.pson }.pson
+        )
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 11, args, pson_result.ptr)
+            val result = pson_result.value!!.asResponse?.getResultOrThrow() as PsonValue.PsonObject
+            println(result.getDebugString())
+            result
+            println(result)
+            result.toMap()
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+//        TODO("Implement this function")
+    }
+
+    /**
+     * Subscribes for the KVDB module main events.
+     *
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun subscribeForKvdbEvents() = memScoped{
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs()
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 12, args, pson_result.ptr)
+            pson_result.value!!.asResponse?.getResultOrThrow()
+            Unit
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Unsubscribes from the KVDB module main events.
+     *
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun unsubscribeFromKvdbEvents() = memScoped{
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs()
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 13, args, pson_result.ptr)
+            pson_result.value!!.asResponse?.getResultOrThrow()
+            Unit
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Subscribes for events in given KVDB.
+     *
+     * @param kvdbId ID of the KVDB to subscribe
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun subscribeForEntryEvents(kvdbId: String) = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(
+            kvdbId.pson
+        )
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 14, args, pson_result.ptr)
+            pson_result.value!!.asResponse?.getResultOrThrow()
+            Unit
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Unsubscribes from events in given KVDB.
+     *
+     * @param kvdbId ID of the KVDB to unsubscribe
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun unsubscribeFromEntryEvents(kvdbId: String) = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(
+            kvdbId.pson
+        )
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 15, args, pson_result.ptr)
+            pson_result.value!!.asResponse?.getResultOrThrow()
+            Unit
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    //TODO: Implement "hasEntry"
+
+    /**
+     * Frees memory.
+     *
+     * @throws Exception when instance is currently closed.
+     */
+    actual override fun close() {
+        privmx_endpoint_freeKvdbApi(nativeKvdbApi.value)
+        _nativeKvdbApi.value = null
+    }
+}

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersFromPson.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersFromPson.kt
@@ -11,6 +11,9 @@
 
 package com.simplito.kotlin.privmx_endpoint.utils
 
+import com.simplito.kotlin.privmx_endpoint.model.Kvdb
+import com.simplito.kotlin.privmx_endpoint.model.KvdbEntry
+import com.simplito.kotlin.privmx_endpoint.model.ServerKvdbEntryInfo
 import com.simplito.kotlin.privmx_endpoint.model.BIP39
 import com.simplito.kotlin.privmx_endpoint.model.BridgeIdentity
 import com.simplito.kotlin.privmx_endpoint.model.ContainerPolicy
@@ -198,6 +201,11 @@ internal fun <T> PsonObject.toPagingList(mapper: PsonObject.() -> T) = PagingLis
     this["readItems"]!!.typedList().map { (it as PsonObject).mapper() }
 )
 
+internal inline fun <reified T: Any> PsonObject.toValuePagingList() = PagingList(
+    this["totalAvailable"]?.typedValue(),
+    this["readItems"]!!.typedList().map { it.typedValue<T>() }
+)
+
 internal fun PsonObject.toEvent(): Event<*> = Event(
     this["type"]!!.typedValue(),
     this["channel"]!!.typedValue(),
@@ -290,6 +298,48 @@ internal fun PsonObject.toVerificationRequest(): VerificationRequest = Verificat
     this["date"]!!.typedValue(),
     (this["bridgeIdentity"] as PsonObject?)?.toBridgeIdentity(),
 )
+
+internal fun PsonObject.toKvdb(): Kvdb = Kvdb(
+    this["contextId"]!!.typedValue(),
+    this["kvdbId"]!!.typedValue(),
+    this["createDate"]!!.typedValue(),
+    this["creator"]!!.typedValue(),
+    this["lastModificationDate"]?.typedValue(),
+    this["lastModifier"]!!.typedValue(),
+    this["users"]!!.typedList().map { it.typedValue() },
+    this["managers"]!!.typedList().map { it.typedValue() },
+    this["version"]?.typedValue(),
+    this["publicMeta"]!!.typedValue(),
+    this["privateMeta"]!!.typedValue(),
+    this["entries"]?.typedValue(),
+    this["lastEntryDate"]?.typedValue(),
+    (this["policy"] as PsonObject?)?.toContainerPolicy(),
+    this["statusCode"]?.typedValue(),
+    this["schemaVersion"]?.typedValue(),
+)
+
+internal fun PsonObject.toKvdbEntry(): KvdbEntry = KvdbEntry(
+    (this["info"] as PsonObject).toServerKvdbEntryInfo(),
+    this["publicMeta"]!!.typedValue(),
+    this["privateMeta"]!!.typedValue(),
+    this["data"]!!.typedValue(),
+    this["authorPubKey"]!!.typedValue(),
+    this["version"]?.typedValue(),
+    this["statusCode"]?.typedValue(),
+    this["schemaVersion"]?.typedValue(),
+)
+
+internal fun PsonObject.toServerKvdbEntryInfo(): ServerKvdbEntryInfo = ServerKvdbEntryInfo(
+    this["kvdbId"]!!.typedValue(),
+    this["key"]!!.typedValue(),
+    this["createDate"]?.typedValue(),
+    this["author"]!!.typedValue()
+)
+
+@Throws(ClassCastException::class)
+internal inline fun <reified T : Any> PsonObject.toMap(): Map<String,T> {
+    return mapOf(*(getValue().map { it.key to it.value.typedValue<T>() }.toTypedArray()))
+}
 
 @Throws(ClassCastException::class)
 internal inline fun <reified T : Any> PsonValue<Any>.typedValue(): T {

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersFromPson.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersFromPson.kt
@@ -11,6 +11,9 @@
 
 package com.simplito.kotlin.privmx_endpoint.utils
 
+import com.simplito.java.privmx_endpoint.model.events.KvdbDeletedEntryEventData
+import com.simplito.java.privmx_endpoint.model.events.KvdbDeletedEventData
+import com.simplito.java.privmx_endpoint.model.events.KvdbStatsEventData
 import com.simplito.kotlin.privmx_endpoint.model.Kvdb
 import com.simplito.kotlin.privmx_endpoint.model.KvdbEntry
 import com.simplito.kotlin.privmx_endpoint.model.ServerKvdbEntryInfo
@@ -256,6 +259,21 @@ internal fun PsonObject.toThreadStatsEventData() = ThreadStatsEventData(
     this["messagesCount"]?.typedValue(),
 )
 
+internal fun PsonObject.toKvdbDeletedEventData() = KvdbDeletedEventData(
+    this["kvdbId"]!!.typedValue()
+)
+
+internal fun PsonObject.toKvdbStatsEventData() = KvdbStatsEventData(
+    this["kvdbId"]!!.typedValue(),
+    this["lastEntryDate"]!!.typedValue(),
+    this["entries"]!!.typedValue(),
+)
+
+internal fun PsonObject.toKvdbDeletedEntryEventData() = KvdbDeletedEntryEventData(
+    this["kvdbId"]!!.typedValue(),
+    this["kvdbEntryKey"]!!.typedValue()
+)
+
 private val EventDataMappers: Map<String, PsonObject.() -> Any> = mapOf(
     "thread\$Thread" to PsonObject::toThread,
     "thread\$Thread" to PsonObject::toThread,
@@ -276,6 +294,11 @@ private val EventDataMappers: Map<String, PsonObject.() -> Any> = mapOf(
     "inbox\$InboxEntry" to PsonObject::toInboxEntry,
     "inbox\$Inbox" to PsonObject::toInbox,
     "inbox\$Inbox" to PsonObject::toInbox,
+    "kvdb\$Kvdb" to PsonObject::toKvdb,
+    "kvdb\$KvdbDeletedEventData" to PsonObject::toKvdbDeletedEventData,
+    "kvdb\$KvdbStatsEventData" to PsonObject::toKvdbStatsEventData,
+    "kvdb\$KvdbEntry" to PsonObject::toKvdbEntry,
+    "kvdb\$KvdbDeletedEntryEventData" to PsonObject::toKvdbDeletedEntryEventData,
 )
 
 

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.jvm.kt
@@ -52,6 +52,7 @@ actual class KvdbApi actual constructor(connection: Connection) : AutoCloseable 
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    @JvmOverloads
     actual external fun createKvdb(
         contextId: String,
         users: List<UserWithPubKey>,
@@ -79,6 +80,7 @@ actual class KvdbApi actual constructor(connection: Connection) : AutoCloseable 
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    @JvmOverloads
     actual external fun updateKvdb(
         kvdbId: String,
         users: List<UserWithPubKey>,
@@ -131,6 +133,7 @@ actual class KvdbApi actual constructor(connection: Connection) : AutoCloseable 
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    @JvmOverloads
     actual external fun listKvdbs(
         contextId: String,
         skip: Long,
@@ -159,6 +162,19 @@ actual class KvdbApi actual constructor(connection: Connection) : AutoCloseable 
     ): KvdbEntry
 
     /**
+     * Check whether the KVDB entry exists.
+     *
+     * @param kvdbId KVDB ID of the KVDB entry to check
+     * @param key    key of the KVDB entry to check
+     * @return 'true' if the KVDB has an entry with given key, 'false' otherwise
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun hasEntry(kvdbId: String, key: String): Boolean
+
+    /**
      * Gets a list of KVDB entries keys from a KVDB.
      *
      * @param kvdbId      ID of the KVDB to list KVDB entries from
@@ -174,6 +190,7 @@ actual class KvdbApi actual constructor(connection: Connection) : AutoCloseable 
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    @JvmOverloads
     actual external fun listEntriesKeys(
         kvdbId: String,
         skip: Long,
@@ -200,6 +217,7 @@ actual class KvdbApi actual constructor(connection: Connection) : AutoCloseable 
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    @JvmOverloads
     actual external fun listEntries(
         kvdbId: String,
         skip: Long,
@@ -224,6 +242,7 @@ actual class KvdbApi actual constructor(connection: Connection) : AutoCloseable 
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    @JvmOverloads
     actual external fun setEntry(
         kvdbId: String,
         key: String,
@@ -305,8 +324,6 @@ actual class KvdbApi actual constructor(connection: Connection) : AutoCloseable 
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
     actual external fun unsubscribeFromEntryEvents(kvdbId: String)
-
-    //TODO: Implement "hasEntry"
 
     /**
      * Frees memory.

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.jvm.kt
@@ -118,16 +118,16 @@ actual class KvdbApi actual constructor(connection: Connection) : AutoCloseable 
     actual external fun getKvdb(kvdbId: String): Kvdb
 
     /**
-     * Gets a list of Kvdbs in given Context.
+     * Gets a list of KVDBs in given Context.
      *
-     * @param contextId   ID of the Context to get the Kvdbs from
+     * @param contextId   ID of the Context to get the KVDBs from
      * @param skip        skip number of elements to skip from result
      * @param limit       limit of elements to return for query
      * @param sortOrder   order of elements in result ("asc" for ascending, "desc" for descending)
      * @param lastId      ID of the element from which query results should start
      * @param queryAsJson stringified JSON object with a custom field to filter result
      * @param sortBy      field by elements are sorted in result
-     * @return list of Kvdbs
+     * @return list of KVDBs
      * @throws IllegalStateException thrown when instance is closed.
      * @throws PrivmxException       thrown when method encounters an exception.
      * @throws NativeException       thrown when method encounters an unknown exception.

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.jvm.kt
@@ -1,0 +1,318 @@
+package com.simplito.kotlin.privmx_endpoint.modules.kvdb
+
+import com.simplito.kotlin.privmx_endpoint.LibLoader
+import com.simplito.kotlin.privmx_endpoint.model.Kvdb
+import com.simplito.kotlin.privmx_endpoint.model.KvdbEntry
+import com.simplito.kotlin.privmx_endpoint.model.ContainerPolicy
+import com.simplito.kotlin.privmx_endpoint.model.PagingList
+import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
+import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
+import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
+import kotlin.IllegalStateException
+import kotlin.Throws
+
+actual class KvdbApi actual constructor(connection: Connection) : AutoCloseable {
+    companion object {
+        init {
+            LibLoader.load()
+        }
+    }
+
+    private val api: Long?
+
+    /**
+     * Creates an instance of `KvdbApi`.
+     *
+     * @param connection instance of 'Connection'
+     * @throws IllegalStateException when given [Connection] is not connected
+     */
+    init {
+        this.api = init(connection)
+    }
+
+    @Throws(IllegalStateException::class)
+    private external fun init(connection: Connection): Long?
+
+    @Throws(IllegalStateException::class)
+    private external fun deinit()
+
+    /**
+     * Creates a new KVDB in given Context.
+     *
+     * @param contextId   ID of the Context to create the KVDB in
+     * @param users       list of [UserWithPubKey] which indicates who will have access to the created KVDB
+     * @param managers    list of [UserWithPubKey] which indicates who will have access (and management rights) to the created KVDB
+     * @param publicMeta  public (unencrypted) metadata
+     * @param privateMeta private (encrypted) metadata
+     * @param policies    KVDB's policies
+     * @return ID of the created KVDB
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun createKvdb(
+        contextId: String,
+        users: List<UserWithPubKey>,
+        managers: List<UserWithPubKey>,
+        publicMeta: ByteArray,
+        privateMeta: ByteArray,
+        policies: ContainerPolicy?
+    ): String
+
+
+    /**
+     * Updates an existing KVDB.
+     *
+     * @param kvdbId              ID of the KVDB to update
+     * @param users               list of [UserWithPubKey] which indicates who will have access to the created KVDB
+     * @param managers            list of [UserWithPubKey] which indicates who will have access (and management rights) to the created KVDB
+     * @param publicMeta          public (unencrypted) metadata
+     * @param privateMeta         private (encrypted) metadata
+     * @param version             current version of the updated KVDB
+     * @param force               force update (without checking version)
+     * @param forceGenerateNewKey force to regenerate a key for the KVDB
+     * @param policies            KVDB's policies
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    actual external fun updateKvdb(
+        kvdbId: String,
+        users: List<UserWithPubKey>,
+        managers: List<UserWithPubKey>,
+        publicMeta: ByteArray,
+        privateMeta: ByteArray,
+        version: Long,
+        force: Boolean,
+        forceGenerateNewKey: Boolean,
+        policies: ContainerPolicy?
+    )
+
+
+    /**
+     * Deletes a KVDB by given KVDB ID.
+     *
+     * @param kvdbId ID of the KVDB to delete
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun deleteKvdb(kvdbId: String)
+
+    /**
+     * Gets a KVDB by given KVDB ID.
+     *
+     * @param kvdbId ID of KVDB to get
+     * @return object containing info about the KVDB
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun getKvdb(kvdbId: String): Kvdb
+
+    /**
+     * Gets a list of Kvdbs in given Context.
+     *
+     * @param contextId   ID of the Context to get the Kvdbs from
+     * @param skip        skip number of elements to skip from result
+     * @param limit       limit of elements to return for query
+     * @param sortOrder   order of elements in result ("asc" for ascending, "desc" for descending)
+     * @param lastId      ID of the element from which query results should start
+     * @param queryAsJson stringified JSON object with a custom field to filter result
+     * @param sortBy      field by elements are sorted in result
+     * @return list of Kvdbs
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun listKvdbs(
+        contextId: String,
+        skip: Long,
+        limit: Long,
+        sortOrder: String,
+        lastId: String?,
+        queryAsJson: String?,
+        sortBy: String?
+    ): PagingList<Kvdb>
+
+
+    /**
+     * Gets a KVDB entry by given KVDB entry key and KVDB ID.
+     *
+     * @param kvdbId KVDB ID of the KVDB entry to get
+     * @param key    key of the KVDB entry to get
+     * @return object containing the KVDB entry
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun getEntry(
+        kvdbId: String,
+        key: String
+    ): KvdbEntry
+
+    /**
+     * Gets a list of KVDB entries keys from a KVDB.
+     *
+     * @param kvdbId      ID of the KVDB to list KVDB entries from
+     * @param skip        skip number of elements to skip from result
+     * @param limit       limit of elements to return for query
+     * @param sortOrder   order of elements in result ("asc" for ascending, "desc" for descending)
+     * @param lastId      ID of the element from which query results should start
+     * @param queryAsJson stringified JSON object with a custom field to filter result
+     * @param sortBy      field by elements are sorted in result
+     * @return list of KVDB entries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun listEntriesKeys(
+        kvdbId: String,
+        skip: Long,
+        limit: Long,
+        sortOrder: String,
+        lastId: String?,
+        queryAsJson: String?,
+        sortBy: String?
+    ): PagingList<String>
+
+    /**
+     * Gets a list of KVDB entries from a KVDB.
+     *
+     * @param kvdbId      ID of the KVDB to list KVDB entries from
+     * @param skip        skip number of elements to skip from result
+     * @param limit       limit of elements to return for query
+     * @param sortOrder   order of elements in result ("asc" for ascending, "desc" for descending)
+     * @param lastId      ID of the element from which query results should start
+     * @param queryAsJson stringified JSON object with a custom field to filter result
+     * @param sortBy      field by elements are sorted in result
+     * @return list of KVDB entries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun listEntries(
+        kvdbId: String,
+        skip: Long,
+        limit: Long,
+        sortOrder: String,
+        lastId: String?,
+        queryAsJson: String?,
+        sortBy: String?
+    ): PagingList<KvdbEntry>
+
+
+    /**
+     * Sets a KVDB entry in the given KVDB.
+     *
+     * @param kvdbId      ID of the KVDB to set the entry to
+     * @param key         KVDB entry key
+     * @param publicMeta  public KVDB entry metadata
+     * @param privateMeta private KVDB entry metadata
+     * @param data        content of the KVDB entry
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun setEntry(
+        kvdbId: String,
+        key: String,
+        publicMeta: ByteArray,
+        privateMeta: ByteArray,
+        data: ByteArray,
+        version: Long
+    )
+
+    /**
+     * Deletes a KVDB entry by given KVDB entry ID.
+     *
+     * @param kvdbId KVDB ID of the KVDB entry to delete
+     * @param key    key of the KVDB entry to delete
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun deleteEntry(
+        kvdbId: String,
+        key: String
+    )
+
+    /**
+     * Deletes KVDB entries by given KVDB IDs and the list of entry keys.
+     *
+     * @param kvdbId ID of the KVDB database to delete from
+     * @param keys   vector of the keys of the KVDB entries to delete
+     * @return map with the statuses of deletion for every key
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun deleteEntries(
+        kvdbId: String,
+        keys: List<String>
+    ): Map<String, Boolean>
+
+    /**
+     * Subscribes for the KVDB module main events.
+     *
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun subscribeForKvdbEvents()
+
+    /**
+     * Unsubscribes from the KVDB module main events.
+     *
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun unsubscribeFromKvdbEvents()
+
+    /**
+     * Subscribes for events in given KVDB.
+     *
+     * @param kvdbId ID of the KVDB to subscribe
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun subscribeForEntryEvents(kvdbId: String)
+
+    /**
+     * Unsubscribes from events in given KVDB.
+     *
+     * @param kvdbId ID of the KVDB to unsubscribe
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun unsubscribeFromEntryEvents(kvdbId: String)
+
+    //TODO: Implement "hasEntry"
+
+    /**
+     * Frees memory.
+     *
+     * @throws Exception when instance is currently closed.
+     */
+    actual override fun close() {
+    }
+}


### PR DESCRIPTION
## PrivMX Endpoint
### ADDITIONS
* `Kvdb` - Model data class holds all available information about a Kvdb.
* `KvdbEntry` - Model data class holds all available information about an Entry.
* `ServerKvdbEntryInfo` - Model data class holds Kvdb entry's information created by the server.
* `KvdbApi` - New Api class manages PrivMX Bridge  Kvdbs and their messages.