### PR TITLE
[FIX]:  Correct syntax error due to missing parenthesis

### DIFF
--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersFromPson.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/utils/ParsersFromPson.kt
@@ -265,6 +265,7 @@ internal fun PsonObject.toContextCustomEventData() = ContextCustomEventData(
     this["userId"]!!.typedValue(),
     this["data"]!!.typedValue(),
     this["statusCode"]!!.typedValue()
+)
 
 internal fun PsonObject.toKvdbDeletedEventData() = KvdbDeletedEventData(
     this["kvdbId"]!!.typedValue()
@@ -302,7 +303,7 @@ private val EventDataMappers: Map<String, PsonObject.() -> Any> = mapOf(
     "inbox\$InboxEntry" to PsonObject::toInboxEntry,
     "inbox\$Inbox" to PsonObject::toInbox,
     "inbox\$Inbox" to PsonObject::toInbox,
-    "event\$ContextCustomEventData" to PsonObject::toContextCustomEventData
+    "event\$ContextCustomEventData" to PsonObject::toContextCustomEventData,
     "kvdb\$Kvdb" to PsonObject::toKvdb,
     "kvdb\$KvdbDeletedEventData" to PsonObject::toKvdbDeletedEventData,
     "kvdb\$KvdbStatsEventData" to PsonObject::toKvdbStatsEventData,


### PR DESCRIPTION
## Description
Add missing parenthesis and comma to ParsersFromPson file.