### PR TITLE
[FEAT]: Implement builders and enums for creating subscription queries

### DIFF
--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/CustomEventSelectorType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/CustomEventSelectorType.kt
@@ -1,0 +1,5 @@
+package com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes
+
+enum class CustomEventSelectorType : EventSelectorType {
+    CONTEXT_ID
+}

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/CustomEventSelectorType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/CustomEventSelectorType.kt
@@ -1,5 +1,12 @@
 package com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes
 
+/**
+ * Specifies the type of identifier used to select a custom event.
+ * This enum defines the possible types of selectors for custom events.
+ */
 enum class CustomEventSelectorType : EventSelectorType {
+    /**
+     * Selects events based on the ID of the context.
+     */
     CONTEXT_ID
 }

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/EventSelectorType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/EventSelectorType.kt
@@ -1,3 +1,6 @@
 package com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes
 
+/**
+ * The base interface for enums specifying selector event types.
+ */
 interface EventSelectorType 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/EventSelectorType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/EventSelectorType.kt
@@ -1,0 +1,3 @@
+package com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes
+
+interface EventSelectorType 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/InboxEventSelectorType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/InboxEventSelectorType.kt
@@ -1,7 +1,21 @@
 package com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes
 
+/**
+ * Specifies the type of identifier used to select an inbox event.
+ * Inbox events can be targeted based on different levels of granularity within the inbox structure.
+ * This enum defines the possible types of selectors for these events.
+ */
 enum class InboxEventSelectorType : EventSelectorType {
+    /**
+     * Selects events based on the ID of the context.
+     */
     CONTEXT_ID,
+    /**
+     * Selects events based on the ID of the inbox.
+     */
     INBOX_ID,
+    /**
+     * Selects events based on the ID of a specific entry.
+     */
     ENTRY_ID
 }

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/InboxEventSelectorType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/InboxEventSelectorType.kt
@@ -1,0 +1,7 @@
+package com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes
+
+enum class InboxEventSelectorType : EventSelectorType {
+    CONTEXT_ID,
+    INBOX_ID,
+    ENTRY_ID
+}

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/KvdbEventSelectorType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/KvdbEventSelectorType.kt
@@ -1,0 +1,7 @@
+package com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes
+
+enum class KvdbEventSelectorType : EventSelectorType {
+    CONTEXT_ID,
+    KVDB_ID,
+    ENTRY_ID
+}

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/KvdbEventSelectorType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/KvdbEventSelectorType.kt
@@ -1,7 +1,17 @@
 package com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes
 
+/**
+ * Specifies the type of identifier used to select a KVDB event.
+ * KVDB events can be targeted based on different levels of granularity within the KVDB structure.
+ * This enum defines the possible types of selectors for these events.
+ */
 enum class KvdbEventSelectorType : EventSelectorType {
+    /**
+     * Selects events based on the ID of the context.
+     */
     CONTEXT_ID,
+    /**
+     * Selects events based on the ID of the KVDB.
+     */
     KVDB_ID,
-    ENTRY_ID
 }

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/StoreEventSelectorType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/StoreEventSelectorType.kt
@@ -1,7 +1,21 @@
 package com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes
 
+/**
+ * Specifies the type of identifier used to select a store event.
+ * Store events can be targeted based on different levels of granularity within the store structure.
+ * This enum defines the possible types of selectors for these events.
+ */
 enum class StoreEventSelectorType : EventSelectorType {
+    /**
+     * Selects events based on the ID of the context.
+     */
     CONTEXT_ID,
+    /**
+     * Selects events based on the ID of the store.
+     */
     STORE_ID,
+    /**
+     * Selects events based on the ID of a specific file.
+     */
     FILE_ID
 }

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/StoreEventSelectorType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/StoreEventSelectorType.kt
@@ -1,0 +1,7 @@
+package com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes
+
+enum class StoreEventSelectorType : EventSelectorType {
+    CONTEXT_ID,
+    STORE_ID,
+    FILE_ID
+}

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/ThreadEventSelectorType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/ThreadEventSelectorType.kt
@@ -1,0 +1,7 @@
+package com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes
+
+enum class ThreadEventSelectorType : EventSelectorType {
+    CONTEXT_ID,
+    THREAD_ID,
+    MESSAGE_ID
+}

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/ThreadEventSelectorType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventSelectorTypes/ThreadEventSelectorType.kt
@@ -1,7 +1,21 @@
 package com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes
 
+/**
+ * Specifies the type of identifier used to select a thread event.
+ * Thread events can be targeted based on different levels of granularity within the thread structure.
+ * This enum defines the possible types of selectors for these events.
+ */
 enum class ThreadEventSelectorType : EventSelectorType {
+    /**
+     * Selects events based on the ID of the context.
+     */
     CONTEXT_ID,
+    /**
+     * Selects events based on the ID of the thread.
+     */
     THREAD_ID,
+    /**
+     * Selects events based on the ID of a specific message.
+     */
     MESSAGE_ID
 }

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/EventType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/EventType.kt
@@ -1,3 +1,6 @@
 package com.simplito.kotlin.privmx_endpoint.model.events.eventTypes
 
+/**
+ * The base interface for enums specifying event types.
+ */
 interface EventType 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/EventType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/EventType.kt
@@ -1,0 +1,3 @@
+package com.simplito.kotlin.privmx_endpoint.model.events.eventTypes
+
+interface EventType 

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/InboxEventType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/InboxEventType.kt
@@ -1,9 +1,33 @@
 package com.simplito.kotlin.privmx_endpoint.model.events.eventTypes
 
+/**
+ * Defines the types of events that can occur within the inbox for which a client can subscribe.
+ * This enum lists the various actions or changes that can happen to
+ * inboxes and their entries, allowing observers to be notified of specific occurrences.
+ */
 enum class InboxEventType : EventType {
+    /**
+     * Type of event triggered when a new inbox is created.
+     */
     INBOX_CREATE,
+    /**
+     * Type of event triggered when an existing inbox is updated.
+     */
     INBOX_UPDATE,
+    /**
+     * Type of event triggered when an inbox is deleted.
+     */
     INBOX_DELETE,
+    /**
+     * Type of event triggered when a new entry is created within an inbox.
+     */
     ENTRY_CREATE,
-    ENTRY_DELETE
+    /**
+     * Type of event triggered when a new entry is created within an inbox.
+     */
+    ENTRY_DELETE,
+    /**
+     * Type of event triggered when a collection changes.
+     */
+    COLLECTION_CHANGE
 }

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/InboxEventType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/InboxEventType.kt
@@ -1,0 +1,9 @@
+package com.simplito.kotlin.privmx_endpoint.model.events.eventTypes
+
+enum class InboxEventType : EventType {
+    INBOX_CREATE,
+    INBOX_UPDATE,
+    INBOX_DELETE,
+    ENTRY_CREATE,
+    ENTRY_DELETE
+}

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/KvdbEventType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/KvdbEventType.kt
@@ -1,0 +1,11 @@
+package com.simplito.kotlin.privmx_endpoint.model.events.eventTypes
+
+enum class KvdbEventType : EventType {
+    KVDB_CREATE,
+    KVDB_UPDATE,
+    KVDB_DELETE,
+    KVDB_STATS,
+    ENTRY_CREATE,
+    ENTRY_UPDATE,
+    ENTRY_DELETE
+}

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/KvdbEventType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/KvdbEventType.kt
@@ -1,11 +1,41 @@
 package com.simplito.kotlin.privmx_endpoint.model.events.eventTypes
 
+/**
+ * Defines the types of events that can occur within the KVDB for which a client can subscribe.
+ * This enum lists the various actions or changes that can happen to
+ * KVDBs and their entries, allowing observers to be notified of specific occurrences.
+ */
 enum class KvdbEventType : EventType {
+    /**
+     * Type of event triggered when a new KVDB is created.
+     */
     KVDB_CREATE,
+    /**
+     * Type of event triggered when an existing KVDB is updated.
+     */
     KVDB_UPDATE,
+    /**
+     * Type of event triggered when a KVDB is deleted.
+     */
     KVDB_DELETE,
+    /**
+     * Type of event triggered when a KVDB statistics are updated.
+     */
     KVDB_STATS,
+    /**
+     * Type of event triggered when a new entry is created within a KVDB.
+     */
     ENTRY_CREATE,
+    /**
+     * Type of event triggered when an existing KVDB entry is updated.
+     */
     ENTRY_UPDATE,
-    ENTRY_DELETE
+    /**
+     * Type of event triggered when a KVDB entry is deleted.
+     */
+    ENTRY_DELETE,
+    /**
+     * Type of event triggered when a collection changes.
+     */
+    COLLECTION_CHANGE
 }

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/StoreEventType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/StoreEventType.kt
@@ -1,11 +1,41 @@
 package com.simplito.kotlin.privmx_endpoint.model.events.eventTypes
 
+/**
+ * Defines the types of events that can occur within the store for which a client can subscribe.
+ * This enum lists the various actions or changes that can happen to
+ * stores and their files, allowing observers to be notified of specific occurrences.
+ */
 enum class StoreEventType : EventType {
+    /**
+     * Type of event triggered when a new store is created.
+     */
     STORE_CREATE,
+    /**
+     * Type of event triggered when an existing store is updated.
+     */
     STORE_UPDATE,
+    /**
+     * Type of event triggered when a store is deleted.
+     */
     STORE_DELETE,
+    /**
+     * Type of event triggered when a store statistics are updated.
+     */
     STORE_STATS,
+    /**
+     * Type of event triggered when a new file is created within a store.
+     */
     FILE_CREATE,
+    /**
+     * Type of event triggered when an existing file is updated.
+     */
     FILE_UPDATE,
-    FILE_DELETE
+    /**
+     * Type of event triggered when a file is deleted.
+     */
+    FILE_DELETE,
+    /**
+     * Type of event triggered when a collection changes.
+     */
+    COLLECTION_CHANGE
 }

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/StoreEventType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/StoreEventType.kt
@@ -1,0 +1,11 @@
+package com.simplito.kotlin.privmx_endpoint.model.events.eventTypes
+
+enum class StoreEventType : EventType {
+    STORE_CREATE,
+    STORE_UPDATE,
+    STORE_DELETE,
+    STORE_STATS,
+    FILE_CREATE,
+    FILE_UPDATE,
+    FILE_DELETE
+}

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/ThreadEventType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/ThreadEventType.kt
@@ -1,11 +1,41 @@
 package com.simplito.kotlin.privmx_endpoint.model.events.eventTypes
 
+/**
+ * Defines the types of events that can occur within the thread for which a client can subscribe.
+ * This enum lists the various actions or changes that can happen to
+ * threads and their messages, allowing observers to be notified of specific occurrences.
+ */
 enum class ThreadEventType : EventType {
+    /**
+     * Type of event triggered when a new thread is created.
+     */
     THREAD_CREATE,
+    /**
+     * Type of event triggered when an existing thread is updated.
+     */
     THREAD_UPDATE,
+    /**
+     * Type of event triggered when a thread is deleted.
+     */
     THREAD_DELETE,
+    /**
+     * Type of event triggered when a thread statistics are updated.
+     */
     THREAD_STATS,
+    /**
+     * Type of event triggered when a new message is created within a thread.
+     */
     MESSAGE_CREATE,
+    /**
+     * Type of event triggered when an existing message is updated.
+     */
     MESSAGE_UPDATE,
-    MESSAGE_DELETE
+    /**
+     * Type of event triggered when a message is deleted.
+     */
+    MESSAGE_DELETE,
+    /**
+     * Type of event triggered when a collection changes.
+     */
+    COLLECTION_CHANGE
 }

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/ThreadEventType.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/model/events/eventTypes/ThreadEventType.kt
@@ -1,0 +1,11 @@
+package com.simplito.kotlin.privmx_endpoint.model.events.eventTypes
+
+enum class ThreadEventType : EventType {
+    THREAD_CREATE,
+    THREAD_UPDATE,
+    THREAD_DELETE,
+    THREAD_STATS,
+    MESSAGE_CREATE,
+    MESSAGE_UPDATE,
+    MESSAGE_DELETE
+}

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/event/EventApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/event/EventApi.kt
@@ -12,6 +12,7 @@
 package com.simplito.kotlin.privmx_endpoint.modules.event
 
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.CustomEventSelectorType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -48,32 +49,45 @@ constructor(connection: Connection) : AutoCloseable {
     )
 
     /**
-     * Subscribe for the custom events on the given channel.
+     * Subscribe for the custom events on the given subscription query.
      *
-     * @param contextId   ID of the Context
-     * @param channelName name of the Channel
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    fun subscribeForCustomEvents(contextId: String, channelName: String)
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun subscribeFor(subscriptionQueries: List<String>): List<String>
 
     /**
-     * Unsubscribe from the custom events on the given channel.
+     * Unsubscribe from events with the given subscriptionId.
      *
-     * @param contextId   ID of the Context
-     * @param channelName name of the Channel
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    fun unsubscribeFromCustomEvents(contextId: String, channelName: String)
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun unsubscribeFrom(subscriptionIds: List<String>)
+
+    /**
+     * Generate subscription Query for the custom events.
+     *
+     * @param channelName  name of the Channel
+     * @param selectorType selector of scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun buildSubscriptionQuery(
+        channelName: String,
+        selectorType: CustomEventSelectorType,
+        selectorId: String
+    ): String
 
     /**
      * Frees memory.

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/inbox/InboxApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/inbox/InboxApi.kt
@@ -17,6 +17,8 @@ import com.simplito.kotlin.privmx_endpoint.model.InboxEntry
 import com.simplito.kotlin.privmx_endpoint.model.InboxPublicView
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.InboxEventSelectorType
+import com.simplito.kotlin.privmx_endpoint.model.events.eventTypes.InboxEventType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -365,54 +367,42 @@ constructor(
     fun closeFile(fileHandle: Long): String
 
     /**
-     * Subscribes for the Inbox module main events.
+     * Subscribe for the Inbox events on the given subscription query.
      *
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    fun subscribeForInboxEvents()
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun subscribeFor(subscriptionQueries: List<String>): List<String>
 
     /**
-     * Subscribes for the Inbox module main events.
+     * Unsubscribe from events with the given subscriptionId.
      *
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    fun unsubscribeFromInboxEvents()
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun unsubscribeFrom(subscriptionIds: List<String>)
 
     /**
-     * Subscribes for events in given Inbox.
+     * Generate subscription Query for the Inbox events.
      *
-     * @param inboxId ID of the Inbox to subscribe
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param eventType    type of event you listen for
+     * @param selectorType scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    fun subscribeForEntryEvents(inboxId: String)
-
-    /**
-     * Unsubscribes from events in given Inbox.
-     *
-     * @param inboxId ID of the Inbox to unsubscribe
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
-     */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    fun unsubscribeFromEntryEvents(inboxId: String)
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun buildSubscriptionQuery(
+        eventType: InboxEventType, selectorType: InboxEventSelectorType, selectorId: String): String
 
     /**
      * Frees memory.

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.kt
@@ -5,6 +5,8 @@ import com.simplito.kotlin.privmx_endpoint.model.Kvdb
 import com.simplito.kotlin.privmx_endpoint.model.KvdbEntry
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.KvdbEventSelectorType
+import com.simplito.kotlin.privmx_endpoint.model.events.eventTypes.KvdbEventType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -258,46 +260,45 @@ expect class KvdbApi(connection: Connection) : AutoCloseable {
     ): Map<String, Boolean>
 
     /**
-     * Subscribes for the KVDB module main events.
+     * Subscribe for the KVDB events on the given subscription query.
      *
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
      * @throws IllegalStateException thrown when instance is closed.
      * @throws PrivmxException       thrown when method encounters an exception.
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    fun subscribeForKvdbEvents()
+    fun subscribeFor(subscriptionQueries: List<String>): List<String>
 
     /**
-     * Unsubscribes from the KVDB module main events.
+     * Unsubscribe from events with the given subscriptionId.
      *
+     * @param subscriptionIds list of subscriptionId
      * @throws IllegalStateException thrown when instance is closed.
      * @throws PrivmxException       thrown when method encounters an exception.
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    fun unsubscribeFromKvdbEvents()
+    fun unsubscribeFrom(subscriptionIds: List<String>)
 
     /**
-     * Subscribes for events in given KVDB.
+     * Generate subscription Query for the KVDB events.
      *
-     * @param kvdbId ID of the KVDB to subscribe
+     * @param eventType    type of event you listen for
+     * @param selectorType scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
      * @throws IllegalStateException thrown when instance is closed.
      * @throws PrivmxException       thrown when method encounters an exception.
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    fun subscribeForEntryEvents(kvdbId: String)
-
-    /**
-     * Unsubscribes from events in given KVDB.
-     *
-     * @param kvdbId ID of the KVDB to unsubscribe
-     * @throws IllegalStateException thrown when instance is closed.
-     * @throws PrivmxException       thrown when method encounters an exception.
-     * @throws NativeException       thrown when method encounters an unknown exception.
-     */
-    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    fun unsubscribeFromEntryEvents(kvdbId: String)
+    fun buildSubscriptionQuery(
+        eventType: KvdbEventType,
+        selectorType: KvdbEventSelectorType,
+        selectorId: String
+    ): String
 
     /**
      * Frees memory.

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/store/StoreApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/store/StoreApi.kt
@@ -15,6 +15,8 @@ import com.simplito.kotlin.privmx_endpoint.model.File
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.Store
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.StoreEventSelectorType
+import com.simplito.kotlin.privmx_endpoint.model.events.eventTypes.StoreEventType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -356,62 +358,45 @@ constructor(connection: Connection) : AutoCloseable {
     fun closeFile(fileHandle: Long): String
 
     /**
-     * Subscribes for the Store module main events.
+     * Subscribe for the Store events on the given subscription query.
      *
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class,
-        NativeException::class,
-        IllegalStateException::class
-    )
-    fun subscribeForStoreEvents()
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun subscribeFor(subscriptionQueries: List<String>): List<String>
 
     /**
-     * Unsubscribes from the Store module main events.
+     * Unsubscribe from events with the given subscriptionId.
      *
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class,
-        NativeException::class,
-        IllegalStateException::class
-    )
-    fun unsubscribeFromStoreEvents()
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun unsubscribeFrom(subscriptionIds: List<String>)
 
     /**
-     * Subscribes for events in given Store.
+     * Generate subscription Query for the Store events.
      *
-     * @param storeId ID of the Store to subscribe
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param eventType    type of event you listen for
+     * @param selectorType scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class,
-        NativeException::class,
-        IllegalStateException::class
-    )
-    fun subscribeForFileEvents(storeId: String)
-
-    /**
-     * Unsubscribes from events in given Store.
-     *
-     * @param storeId ID of the `Store` to unsubscribe
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     */
-    @Throws(
-        PrivmxException::class,
-        NativeException::class,
-        IllegalStateException::class
-    )
-    fun unsubscribeFromFileEvents(storeId: String)
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    fun buildSubscriptionQuery(
+        eventType: StoreEventType,
+        selectorType: StoreEventSelectorType,
+        selectorId: String
+    ): String
 
     /**
      * Frees memory.

--- a/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/thread/ThreadApi.kt
+++ b/privmx-endpoint/src/commonMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/thread/ThreadApi.kt
@@ -15,6 +15,8 @@ import com.simplito.kotlin.privmx_endpoint.model.Message
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.Thread
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.ThreadEventSelectorType
+import com.simplito.kotlin.privmx_endpoint.model.events.eventTypes.ThreadEventType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -221,46 +223,45 @@ constructor(connection: Connection) : AutoCloseable {
     )
 
     /**
-     * Subscribes for the Thread module main events.
+     * Subscribe for the Thread events on the given subscription query.
      *
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    fun subscribeForThreadEvents()
+    fun subscribeFor(subscriptionQueries: List<String>): List<String>
 
     /**
-     * Unsubscribes from the Thread module main events.
+     * Unsubscribe from events with the given subscriptionId.
      *
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    fun unsubscribeFromThreadEvents()
+    fun unsubscribeFrom(subscriptionIds: List<String>)
 
     /**
-     * Subscribes for events in given Thread.
+     * Generate subscription Query for the Thread events.
      *
-     * @param threadId ID of the Thread to subscribe
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param eventType    type of event you listen for
+     * @param selectorType scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    fun subscribeForMessageEvents(threadId: String)
-
-    /**
-     * Unsubscribes from events in given Thread.
-     *
-     * @param threadId ID of the Thread to unsubscribe
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     */
-    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    fun unsubscribeFromMessageEvents(threadId: String)
+    fun buildSubscriptionQuery(
+        eventType: ThreadEventType,
+        selectorType: ThreadEventSelectorType,
+        selectorId: String
+    ): String
 
     /**
      * Frees memory.

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/event/EventApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/event/EventApi.ios.kt
@@ -13,12 +13,15 @@ package com.simplito.kotlin.privmx_endpoint.modules.event
 
 import cnames.structs.pson_value
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.CustomEventSelectorType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
 import com.simplito.kotlin.privmx_endpoint.utils.asResponse
 import com.simplito.kotlin.privmx_endpoint.utils.makeArgs
 import com.simplito.kotlin.privmx_endpoint.utils.pson
+import com.simplito.kotlin.privmx_endpoint.utils.typedList
+import com.simplito.kotlin.privmx_endpoint.utils.typedValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.allocPointerTo
 import kotlinx.cinterop.memScoped
@@ -93,51 +96,85 @@ actual constructor(connection: Connection) : AutoCloseable {
     }
 
     /**
-     * Subscribe for the custom events on the given channel.
+     * Subscribe for the custom events on the given subscription query.
      *
-     * @param contextId   ID of the Context
-     * @param channelName name of the Channel
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual fun subscribeForCustomEvents(contextId: String, channelName: String): Unit = memScoped {
-        val result = allocPointerTo<pson_value>()
-        val args = makeArgs(
-            contextId.pson, channelName.pson
-        )
+    @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    actual fun subscribeFor(subscriptionQueries: List<String>): List<String> = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(subscriptionQueries.map { it.pson }.pson)
+
         try {
-            privmx_endpoint_execEventApi(nativeEventApi.value, 2, args, result.ptr)
-            result.value?.asResponse?.getResultOrThrow()
+            privmx_endpoint_execEventApi(nativeEventApi.value, 4, args, pson_result.ptr)
+            val list = pson_result.value!!.asResponse?.getResultOrThrow()!!
+            list.typedList().map { it.typedValue() }
         } finally {
             pson_free_value(args)
-            pson_free_result(result.value)
+            pson_free_result(pson_result.value)
         }
     }
 
     /**
-     * Unsubscribe from the custom events on the given channel.
+     * Unsubscribe from events with the given subscriptionId.
      *
-     * @param contextId   ID of the Context
-     * @param channelName name of the Channel
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual fun unsubscribeFromCustomEvents(contextId: String, channelName: String): Unit =
-        memScoped {
-            val result = allocPointerTo<pson_value>()
-            val args = makeArgs(contextId.pson, channelName.pson)
-            try {
-                privmx_endpoint_execEventApi(nativeEventApi.value, 3, args, result.ptr)
-                result.value?.asResponse?.getResultOrThrow()
-            } finally {
-                pson_free_value(args)
-                pson_free_result(result.value)
-            }
+    @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    actual fun unsubscribeFrom(subscriptionIds: List<String>) = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(subscriptionIds.map { it.pson }.pson)
+
+        try {
+            privmx_endpoint_execEventApi(nativeEventApi.value, 5, args, pson_result.ptr)
+            pson_result.value!!.asResponse?.getResultOrThrow()
+            Unit
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
         }
+    }
+
+    /**
+     * Generate subscription Query for the custom events.
+     *
+     * @param channelName  name of the Channel
+     * @param selectorType selector of scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    actual fun buildSubscriptionQuery(
+        channelName: String,
+        selectorType: CustomEventSelectorType,
+        selectorId: String
+    ): String = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(
+            channelName.pson,
+            selectorType.ordinal.toLong().pson,
+            selectorId.pson
+        )
+
+        try {
+            privmx_endpoint_execEventApi(nativeEventApi.value, 6, args, pson_result.ptr)
+            val query = pson_result.value!!.asResponse?.getResultOrThrow()!!
+            query.typedValue()
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
 
     /**
      * Frees memory.

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/inbox/InboxApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/inbox/InboxApi.ios.kt
@@ -19,6 +19,8 @@ import com.simplito.kotlin.privmx_endpoint.model.InboxEntry
 import com.simplito.kotlin.privmx_endpoint.model.InboxPublicView
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.InboxEventSelectorType
+import com.simplito.kotlin.privmx_endpoint.model.events.eventTypes.InboxEventType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -35,6 +37,7 @@ import com.simplito.kotlin.privmx_endpoint.utils.toInbox
 import com.simplito.kotlin.privmx_endpoint.utils.toInboxEntry
 import com.simplito.kotlin.privmx_endpoint.utils.toInboxPublicView
 import com.simplito.kotlin.privmx_endpoint.utils.toPagingList
+import com.simplito.kotlin.privmx_endpoint.utils.typedList
 import com.simplito.kotlin.privmx_endpoint.utils.typedValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.allocPointerTo
@@ -44,11 +47,7 @@ import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
 import libprivmxendpoint.privmx_endpoint_execInboxApi
 import libprivmxendpoint.privmx_endpoint_freeInboxApi
-import libprivmxendpoint.privmx_endpoint_freeStoreApi
-import libprivmxendpoint.privmx_endpoint_freeThreadApi
 import libprivmxendpoint.privmx_endpoint_newInboxApi
-import libprivmxendpoint.privmx_endpoint_newStoreApi
-import libprivmxendpoint.privmx_endpoint_newThreadApi
 import libprivmxendpoint.pson_free_result
 import libprivmxendpoint.pson_free_value
 import libprivmxendpoint.pson_new_array
@@ -659,20 +658,44 @@ actual constructor(
     }
 
     /**
-     * Subscribes for the Inbox module main events.
+     * Subscribe for the Inbox events on the given subscription query.
      *
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    actual fun subscribeForInboxEvents() = memScoped {
+    @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    actual fun subscribeFor(subscriptionQueries: List<String>): List<String> = memScoped {
         val pson_result = allocPointerTo<pson_value>()
-        val args = makeArgs()
+        val args = makeArgs(subscriptionQueries.map { it.pson }.pson)
+
         try {
-            privmx_endpoint_execInboxApi(nativeInboxApi.value, 18, args, pson_result.ptr)
+            privmx_endpoint_execInboxApi(nativeInboxApi.value, 22, args, pson_result.ptr)
+            val list = pson_result.value!!.asResponse?.getResultOrThrow()!!
+            list.typedList().map { it.typedValue() }
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Unsubscribe from events with the given subscriptionId.
+     *
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    actual fun unsubscribeFrom(subscriptionIds: List<String>) = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(subscriptionIds.map { it.pson }.pson)
+
+        try {
+            privmx_endpoint_execInboxApi(nativeInboxApi.value, 23, args, pson_result.ptr)
             pson_result.value!!.asResponse?.getResultOrThrow()
             Unit
         } finally {
@@ -682,72 +705,33 @@ actual constructor(
     }
 
     /**
-     * Subscribes for the Inbox module main events.
+     * Generate subscription Query for the Inbox events.
      *
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param eventType    type of event you listen for
+     * @param selectorType scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    actual fun unsubscribeFromInboxEvents() = memScoped {
-        val pson_result = allocPointerTo<pson_value>()
-        val args = makeArgs()
-        try {
-            privmx_endpoint_execInboxApi(nativeInboxApi.value, 19, args, pson_result.ptr)
-            pson_result.value!!.asResponse?.getResultOrThrow()
-            Unit
-        } finally {
-            pson_free_value(args)
-            pson_free_result(pson_result.value)
-        }
-    }
-
-    /**
-     * Subscribes for events in given Inbox.
-     *
-     * @param inboxId ID of the Inbox to subscribe
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
-     */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    actual fun subscribeForEntryEvents(inboxId: String) = memScoped {
+    @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    actual fun buildSubscriptionQuery(
+        eventType: InboxEventType,
+        selectorType: InboxEventSelectorType,
+        selectorId: String
+    ): String = memScoped {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs(
-            inboxId.pson
+            eventType.ordinal.toLong().pson,
+            selectorType.ordinal.toLong().pson,
+            selectorId.pson
         )
-        try {
-            privmx_endpoint_execInboxApi(nativeInboxApi.value, 20, args, pson_result.ptr)
-            pson_result.value!!.asResponse?.getResultOrThrow()
-            Unit
-        } finally {
-            pson_free_value(args)
-            pson_free_result(pson_result.value)
-        }
-    }
 
-    /**
-     * Unsubscribes from events in given Inbox.
-     *
-     * @param inboxId ID of the Inbox to unsubscribe
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
-     */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    actual fun unsubscribeFromEntryEvents(inboxId: String) = memScoped {
-        val pson_result = allocPointerTo<pson_value>()
-        val args = makeArgs(inboxId.pson)
         try {
-            privmx_endpoint_execInboxApi(nativeInboxApi.value, 21, args, pson_result.ptr)
-            pson_result.value!!.asResponse?.getResultOrThrow()
-            Unit
+            privmx_endpoint_execInboxApi(nativeInboxApi.value, 24, args, pson_result.ptr)
+            val query = pson_result.value!!.asResponse?.getResultOrThrow()!!
+            query.typedValue()
         } finally {
             pson_free_value(args)
             pson_free_result(pson_result.value)

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.ios.kt
@@ -1,11 +1,13 @@
 package com.simplito.kotlin.privmx_endpoint.modules.kvdb
 
 import cnames.structs.pson_value
+import com.simplito.kotlin.privmx_endpoint.model.ContainerPolicy
 import com.simplito.kotlin.privmx_endpoint.model.Kvdb
 import com.simplito.kotlin.privmx_endpoint.model.KvdbEntry
-import com.simplito.kotlin.privmx_endpoint.model.ContainerPolicy
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.KvdbEventSelectorType
+import com.simplito.kotlin.privmx_endpoint.model.events.eventTypes.KvdbEventType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -15,11 +17,11 @@ import com.simplito.kotlin.privmx_endpoint.utils.asResponse
 import com.simplito.kotlin.privmx_endpoint.utils.makeArgs
 import com.simplito.kotlin.privmx_endpoint.utils.mapOfWithNulls
 import com.simplito.kotlin.privmx_endpoint.utils.pson
-import com.simplito.kotlin.privmx_endpoint.utils.toPagingList
 import com.simplito.kotlin.privmx_endpoint.utils.toKvdb
 import com.simplito.kotlin.privmx_endpoint.utils.toKvdbEntry
-import com.simplito.kotlin.privmx_endpoint.utils.toMap
+import com.simplito.kotlin.privmx_endpoint.utils.toPagingList
 import com.simplito.kotlin.privmx_endpoint.utils.toValuePagingList
+import com.simplito.kotlin.privmx_endpoint.utils.typedList
 import com.simplito.kotlin.privmx_endpoint.utils.typedValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.allocPointerTo
@@ -505,18 +507,44 @@ actual constructor(connection: Connection) : AutoCloseable {
     }
 
     /**
-     * Subscribes for the KVDB module main events.
+     * Subscribe for the KVDB events on the given subscription query.
      *
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
      * @throws IllegalStateException thrown when instance is closed.
      * @throws PrivmxException       thrown when method encounters an exception.
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual fun subscribeForKvdbEvents() = memScoped{
+    actual fun subscribeFor(subscriptionQueries: List<String>): List<String> = memScoped {
         val pson_result = allocPointerTo<pson_value>()
-        val args = makeArgs()
+        val args = makeArgs(subscriptionQueries.map { it.pson }.pson)
+
         try {
-            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 12, args, pson_result.ptr)
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 17, args, pson_result.ptr)
+            val list = pson_result.value!!.asResponse?.getResultOrThrow()!!
+            list.typedList().map { it.typedValue() }
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Unsubscribe from events with the given subscriptionId.
+     *
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun unsubscribeFrom(subscriptionIds: List<String>) = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(subscriptionIds.map { it.pson }.pson)
+
+        try {
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 18, args, pson_result.ptr)
             pson_result.value!!.asResponse?.getResultOrThrow()
             Unit
         } finally {
@@ -526,68 +554,33 @@ actual constructor(connection: Connection) : AutoCloseable {
     }
 
     /**
-     * Unsubscribes from the KVDB module main events.
+     * Generate subscription Query for the KVDB events.
      *
+     * @param eventType    type of event you listen for
+     * @param selectorType scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
      * @throws IllegalStateException thrown when instance is closed.
      * @throws PrivmxException       thrown when method encounters an exception.
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual fun unsubscribeFromKvdbEvents() = memScoped{
-        val pson_result = allocPointerTo<pson_value>()
-        val args = makeArgs()
-        try {
-            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 13, args, pson_result.ptr)
-            pson_result.value!!.asResponse?.getResultOrThrow()
-            Unit
-        } finally {
-            pson_free_value(args)
-            pson_free_result(pson_result.value)
-        }
-    }
-
-    /**
-     * Subscribes for events in given KVDB.
-     *
-     * @param kvdbId ID of the KVDB to subscribe
-     * @throws IllegalStateException thrown when instance is closed.
-     * @throws PrivmxException       thrown when method encounters an exception.
-     * @throws NativeException       thrown when method encounters an unknown exception.
-     */
-    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual fun subscribeForEntryEvents(kvdbId: String) = memScoped {
+    actual fun buildSubscriptionQuery(
+        eventType: KvdbEventType,
+        selectorType: KvdbEventSelectorType,
+        selectorId: String
+    ): String = memScoped {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs(
-            kvdbId.pson
+            eventType.ordinal.toLong().pson,
+            selectorType.ordinal.toLong().pson,
+            selectorId.pson
         )
-        try {
-            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 14, args, pson_result.ptr)
-            pson_result.value!!.asResponse?.getResultOrThrow()
-            Unit
-        } finally {
-            pson_free_value(args)
-            pson_free_result(pson_result.value)
-        }
-    }
 
-    /**
-     * Unsubscribes from events in given KVDB.
-     *
-     * @param kvdbId ID of the KVDB to unsubscribe
-     * @throws IllegalStateException thrown when instance is closed.
-     * @throws PrivmxException       thrown when method encounters an exception.
-     * @throws NativeException       thrown when method encounters an unknown exception.
-     */
-    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual fun unsubscribeFromEntryEvents(kvdbId: String) = memScoped {
-        val pson_result = allocPointerTo<pson_value>()
-        val args = makeArgs(
-            kvdbId.pson
-        )
         try {
-            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 15, args, pson_result.ptr)
-            pson_result.value!!.asResponse?.getResultOrThrow()
-            Unit
+            privmx_endpoint_execKvdbApi(nativeKvdbApi.value, 19, args, pson_result.ptr)
+            val query = pson_result.value!!.asResponse?.getResultOrThrow()!!
+            query.typedValue()
         } finally {
             pson_free_value(args)
             pson_free_result(pson_result.value)

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/store/StoreApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/store/StoreApi.ios.kt
@@ -17,6 +17,8 @@ import com.simplito.kotlin.privmx_endpoint.model.File
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.Store
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.StoreEventSelectorType
+import com.simplito.kotlin.privmx_endpoint.model.events.eventTypes.StoreEventType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -29,6 +31,7 @@ import com.simplito.kotlin.privmx_endpoint.utils.pson
 import com.simplito.kotlin.privmx_endpoint.utils.toFile
 import com.simplito.kotlin.privmx_endpoint.utils.toPagingList
 import com.simplito.kotlin.privmx_endpoint.utils.toStore
+import com.simplito.kotlin.privmx_endpoint.utils.typedList
 import com.simplito.kotlin.privmx_endpoint.utils.typedValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.allocPointerTo
@@ -644,22 +647,44 @@ actual constructor(connection: Connection) :
     }
 
     /**
-     * Subscribes for the Store module main events.
+     * Subscribe for the Store events on the given subscription query.
      *
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class,
-        NativeException::class,
-        IllegalStateException::class
-    )
-    actual fun subscribeForStoreEvents() = memScoped {
+    @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    actual fun subscribeFor(subscriptionQueries: List<String>): List<String> = memScoped {
         val pson_result = allocPointerTo<pson_value>()
-        val args = makeArgs()
+        val args = makeArgs(subscriptionQueries.map { it.pson }.pson)
+
         try {
-            privmx_endpoint_execStoreApi(nativeStoreApi.value, 17, args, pson_result.ptr)
+            privmx_endpoint_execStoreApi(nativeStoreApi.value, 22, args, pson_result.ptr)
+            val list = pson_result.value!!.asResponse?.getResultOrThrow()!!
+            list.typedList().map { it.typedValue() }
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Unsubscribe from events with the given subscriptionId.
+     *
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    actual fun unsubscribeFrom(subscriptionIds: List<String>) = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(subscriptionIds.map { it.pson }.pson)
+
+        try {
+            privmx_endpoint_execStoreApi(nativeStoreApi.value, 23, args, pson_result.ptr)
             pson_result.value!!.asResponse?.getResultOrThrow()
             Unit
         } finally {
@@ -669,80 +694,33 @@ actual constructor(connection: Connection) :
     }
 
     /**
-     * Unsubscribes from the Store module main events.
+     * Generate subscription Query for the Store events.
      *
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param eventType    type of event you listen for
+     * @param selectorType scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class,
-        NativeException::class,
-        IllegalStateException::class
-    )
-    actual fun unsubscribeFromStoreEvents() = memScoped {
-        val pson_result = allocPointerTo<pson_value>()
-        val args = makeArgs()
-        try {
-            privmx_endpoint_execStoreApi(nativeStoreApi.value, 18, args, pson_result.ptr)
-            pson_result.value!!.asResponse?.getResultOrThrow()
-            Unit
-        } finally {
-            pson_free_value(args)
-            pson_free_result(pson_result.value)
-        }
-    }
-
-    /**
-     * Subscribes for events in given Store.
-     *
-     * @param storeId ID of the Store to subscribe
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     */
-    @Throws(
-        PrivmxException::class,
-        NativeException::class,
-        IllegalStateException::class
-    )
-    actual fun subscribeForFileEvents(storeId: String) = memScoped {
+    @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    actual fun buildSubscriptionQuery(
+        eventType: StoreEventType,
+        selectorType: StoreEventSelectorType,
+        selectorId: String
+    ): String = memScoped {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs(
-            storeId.pson
+            eventType.ordinal.toLong().pson,
+            selectorType.ordinal.toLong().pson,
+            selectorId.pson
         )
-        try {
-            privmx_endpoint_execStoreApi(nativeStoreApi.value, 19, args, pson_result.ptr)
-            pson_result.value!!.asResponse?.getResultOrThrow()
-            Unit
-        } finally {
-            pson_free_value(args)
-            pson_free_result(pson_result.value)
-        }
-    }
 
-    /**
-     * Unsubscribes from events in given Store.
-     *
-     * @param storeId ID of the `Store` to unsubscribe
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     */
-    @Throws(
-        PrivmxException::class,
-        NativeException::class,
-        IllegalStateException::class
-    )
-    actual fun unsubscribeFromFileEvents(storeId: String) = memScoped {
-        val pson_result = allocPointerTo<pson_value>()
-        val args = makeArgs(
-            storeId.pson
-        )
         try {
-            privmx_endpoint_execStoreApi(nativeStoreApi.value, 20, args, pson_result.ptr)
-            pson_result.value!!.asResponse?.getResultOrThrow()
-            Unit
+            privmx_endpoint_execStoreApi(nativeStoreApi.value, 24, args, pson_result.ptr)
+            val query = pson_result.value!!.asResponse?.getResultOrThrow()!!
+            query.typedValue()
         } finally {
             pson_free_value(args)
             pson_free_result(pson_result.value)

--- a/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/thread/ThreadApi.ios.kt
+++ b/privmx-endpoint/src/iosMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/thread/ThreadApi.ios.kt
@@ -17,6 +17,8 @@ import com.simplito.kotlin.privmx_endpoint.model.Message
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.Thread
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.ThreadEventSelectorType
+import com.simplito.kotlin.privmx_endpoint.model.events.eventTypes.ThreadEventType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -29,6 +31,7 @@ import com.simplito.kotlin.privmx_endpoint.utils.pson
 import com.simplito.kotlin.privmx_endpoint.utils.toMessage
 import com.simplito.kotlin.privmx_endpoint.utils.toPagingList
 import com.simplito.kotlin.privmx_endpoint.utils.toThread
+import com.simplito.kotlin.privmx_endpoint.utils.typedList
 import com.simplito.kotlin.privmx_endpoint.utils.typedValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.allocPointerTo
@@ -39,9 +42,9 @@ import kotlinx.cinterop.value
 import libprivmxendpoint.privmx_endpoint_execThreadApi
 import libprivmxendpoint.privmx_endpoint_freeThreadApi
 import libprivmxendpoint.privmx_endpoint_newThreadApi
-import libprivmxendpoint.pson_new_array
 import libprivmxendpoint.pson_free_result
 import libprivmxendpoint.pson_free_value
+import libprivmxendpoint.pson_new_array
 
 /**
  * Manages Threads and messages.
@@ -425,18 +428,44 @@ actual constructor(connection: Connection) : AutoCloseable {
     }
 
     /**
-     * Subscribes for the Thread module main events.
+     * Subscribe for the Thread events on the given subscription query.
      *
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual fun subscribeForThreadEvents() = memScoped {
+    actual fun subscribeFor(subscriptionQueries: List<String>): List<String> = memScoped {
         val pson_result = allocPointerTo<pson_value>()
-        val args = makeArgs()
+        val args = makeArgs(subscriptionQueries.map { it.pson }.pson)
+
         try {
-            privmx_endpoint_execThreadApi(nativeThreadApi.value, 11, args, pson_result.ptr)
+            privmx_endpoint_execThreadApi(nativeThreadApi.value, 15, args, pson_result.ptr)
+            val list = pson_result.value!!.asResponse?.getResultOrThrow()!!
+            list.typedList().map { it.typedValue() }
+        } finally {
+            pson_free_value(args)
+            pson_free_result(pson_result.value)
+        }
+    }
+
+    /**
+     * Unsubscribe from events with the given subscriptionId.
+     *
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun unsubscribeFrom(subscriptionIds: List<String>) = memScoped {
+        val pson_result = allocPointerTo<pson_value>()
+        val args = makeArgs(subscriptionIds.map { it.pson }.pson)
+
+        try {
+            privmx_endpoint_execThreadApi(nativeThreadApi.value, 16, args, pson_result.ptr)
             pson_result.value!!.asResponse?.getResultOrThrow()
             Unit
         } finally {
@@ -446,66 +475,33 @@ actual constructor(connection: Connection) : AutoCloseable {
     }
 
     /**
-     * Unsubscribes from the Thread module main events.
+     * Generate subscription Query for the Thread events.
      *
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param eventType    type of event you listen for
+     * @param selectorType scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual fun unsubscribeFromThreadEvents() = memScoped {
-        val pson_result = allocPointerTo<pson_value>()
-        val args = makeArgs()
-        try {
-            privmx_endpoint_execThreadApi(nativeThreadApi.value, 12, args, pson_result.ptr)
-            pson_result.value!!.asResponse?.getResultOrThrow()
-            Unit
-        } finally {
-            pson_free_value(args)
-            pson_free_result(pson_result.value)
-        }
-    }
-
-    /**
-     * Subscribes for events in given Thread.
-     *
-     * @param threadId ID of the Thread to subscribe
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     */
-    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual fun subscribeForMessageEvents(threadId: String) = memScoped {
+    @Throws(exceptionClasses = [PrivmxException::class, NativeException::class, IllegalStateException::class])
+    actual fun buildSubscriptionQuery(
+        eventType: ThreadEventType,
+        selectorType: ThreadEventSelectorType,
+        selectorId: String
+    ): String = memScoped {
         val pson_result = allocPointerTo<pson_value>()
         val args = makeArgs(
-            PsonValue.PsonString(threadId)
+            eventType.ordinal.toLong().pson,
+            selectorType.ordinal.toLong().pson,
+            selectorId.pson
         )
-        try {
-            privmx_endpoint_execThreadApi(nativeThreadApi.value, 13, args, pson_result.ptr)
-            pson_result.value!!.asResponse?.getResultOrThrow()
-            Unit
-        } finally {
-            pson_free_value(args)
-            pson_free_result(pson_result.value)
-        }
-    }
 
-    /**
-     * Unsubscribes from events in given Thread.
-     *
-     * @param threadId ID of the Thread to unsubscribe
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     */
-    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual fun unsubscribeFromMessageEvents(threadId: String) = memScoped {
-        val pson_result = allocPointerTo<pson_value>()
-        val args = makeArgs(PsonValue.PsonString(threadId))
         try {
-            privmx_endpoint_execThreadApi(nativeThreadApi.value, 14, args, pson_result.ptr)
-            pson_result.value!!.asResponse?.getResultOrThrow()
-            Unit
+            privmx_endpoint_execThreadApi(nativeThreadApi.value, 17, args, pson_result.ptr)
+            val query = pson_result.value!!.asResponse?.getResultOrThrow()!!
+            query.typedValue()
         } finally {
             pson_free_value(args)
             pson_free_result(pson_result.value)

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/event/EventApi.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/event/EventApi.jvm.kt
@@ -13,6 +13,7 @@ package com.simplito.kotlin.privmx_endpoint.modules.event
 
 import com.simplito.kotlin.privmx_endpoint.LibLoader
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.CustomEventSelectorType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -62,32 +63,58 @@ actual constructor(connection: Connection) : AutoCloseable {
     )
 
     /**
-     * Subscribe for the custom events on the given channel.
+     * Subscribe for the custom events on the given subscription query.
      *
-     * @param contextId   ID of the Context
-     * @param channelName name of the Channel
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    actual external fun subscribeForCustomEvents(contextId: String, channelName: String)
+    @Throws(PrivmxException::class, NativeException::class, java.lang.IllegalStateException::class)
+    actual external fun subscribeFor(subscriptionQueries: List<String>): List<String>
 
     /**
-     * Unsubscribe from the custom events on the given channel.
+     * Unsubscribe from events with the given subscriptionId.
      *
-     * @param contextId   ID of the Context
-     * @param channelName name of the Channel
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    actual external fun unsubscribeFromCustomEvents(contextId: String, channelName: String)
+    @Throws(PrivmxException::class, NativeException::class, java.lang.IllegalStateException::class)
+    actual external fun unsubscribeFrom(subscriptionIds: List<String>)
+
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    private external fun buildSubscriptionQuery(
+        channelName: String,
+        selectorType: Long,
+        selectorId: String
+    ): String
+
+    /**
+     * Generate subscription Query for the custom events.
+     *
+     * @param channelName  name of the Channel
+     * @param selectorType selector of scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     */
+    @Throws(PrivmxException::class, NativeException::class, java.lang.IllegalStateException::class)
+    actual fun buildSubscriptionQuery(
+        channelName: String,
+        selectorType: CustomEventSelectorType,
+        selectorId: String
+    ): String {
+        return buildSubscriptionQuery(
+            channelName,
+            selectorType.ordinal.toLong(),
+            selectorId
+        )
+    }
 
     /**
      * Frees memory.

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/inbox/InboxApi.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/inbox/InboxApi.jvm.kt
@@ -19,6 +19,8 @@ import com.simplito.kotlin.privmx_endpoint.model.InboxEntry
 import com.simplito.kotlin.privmx_endpoint.model.InboxPublicView
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.InboxEventSelectorType
+import com.simplito.kotlin.privmx_endpoint.model.events.eventTypes.InboxEventType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -385,54 +387,58 @@ actual constructor(
     actual external fun closeFile(fileHandle: Long): String
 
     /**
-     * Subscribes for the Inbox module main events.
+     * Subscribe for the Inbox events on the given subscription query.
      *
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    actual external fun subscribeForInboxEvents()
+    @Throws(PrivmxException::class, NativeException::class, java.lang.IllegalStateException::class)
+    actual external fun subscribeFor(subscriptionQueries: List<String>): List<String>
 
     /**
-     * Subscribes for the Inbox module main events.
+     * Unsubscribe from events with the given subscriptionId.
      *
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    actual external fun unsubscribeFromInboxEvents()
+    @Throws(PrivmxException::class, NativeException::class, java.lang.IllegalStateException::class)
+    actual external fun unsubscribeFrom(subscriptionIds: List<String>)
+
+    @Throws(PrivmxException::class, NativeException::class, java.lang.IllegalStateException::class)
+    private external fun buildSubscriptionQuery(
+        eventType: Long,
+        selectorType: Long,
+        selectorId: String
+    ): String
 
     /**
-     * Subscribes for events in given Inbox.
+     * Generate subscription Query for the Inbox events.
      *
-     * @param inboxId ID of the Inbox to subscribe
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
+     * @param eventType    type of event you listen for
+     * @param selectorType scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    actual external fun subscribeForEntryEvents(inboxId: String)
-
-    /**
-     * Unsubscribes from events in given Inbox.
-     *
-     * @param inboxId ID of the Inbox to unsubscribe
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     * @throws IllegalStateException thrown when instance is closed
-     */
-    @Throws(
-        PrivmxException::class, NativeException::class, IllegalStateException::class
-    )
-    actual external fun unsubscribeFromEntryEvents(inboxId: String)
+    @Throws(PrivmxException::class, NativeException::class, java.lang.IllegalStateException::class)
+    actual fun buildSubscriptionQuery(
+        eventType: InboxEventType,
+        selectorType: InboxEventSelectorType,
+        selectorId: String
+    ): String {
+        return buildSubscriptionQuery(
+            eventType.ordinal.toLong(),
+            selectorType.ordinal.toLong(),
+            selectorId
+        )
+    }
 
     /**
      * Frees memory.

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/kvdb/KvdbApi.jvm.kt
@@ -1,16 +1,16 @@
 package com.simplito.kotlin.privmx_endpoint.modules.kvdb
 
 import com.simplito.kotlin.privmx_endpoint.LibLoader
+import com.simplito.kotlin.privmx_endpoint.model.ContainerPolicy
 import com.simplito.kotlin.privmx_endpoint.model.Kvdb
 import com.simplito.kotlin.privmx_endpoint.model.KvdbEntry
-import com.simplito.kotlin.privmx_endpoint.model.ContainerPolicy
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.KvdbEventSelectorType
+import com.simplito.kotlin.privmx_endpoint.model.events.eventTypes.KvdbEventType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
-import kotlin.IllegalStateException
-import kotlin.Throws
 
 actual class KvdbApi actual constructor(connection: Connection) : AutoCloseable {
     companion object {
@@ -284,46 +284,58 @@ actual class KvdbApi actual constructor(connection: Connection) : AutoCloseable 
     ): Map<String, Boolean>
 
     /**
-     * Subscribes for the KVDB module main events.
+     * Subscribe for the KVDB events on the given subscription query.
      *
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
      * @throws IllegalStateException thrown when instance is closed.
      * @throws PrivmxException       thrown when method encounters an exception.
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual external fun subscribeForKvdbEvents()
+    actual external fun subscribeFor(subscriptionQueries: List<String>): List<String>
 
     /**
-     * Unsubscribes from the KVDB module main events.
+     * Unsubscribe from events with the given subscriptionId.
      *
+     * @param subscriptionIds list of subscriptionId
      * @throws IllegalStateException thrown when instance is closed.
      * @throws PrivmxException       thrown when method encounters an exception.
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual external fun unsubscribeFromKvdbEvents()
+    actual external fun unsubscribeFrom(subscriptionIds: List<String>)
+
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun buildSubscriptionQuery(
+        eventType: KvdbEventType,
+        selectorType: KvdbEventSelectorType,
+        selectorId: String
+    ): String {
+        return buildSubscriptionQuery(
+            eventType.ordinal.toLong(),
+            selectorType.ordinal.toLong(),
+            selectorId
+        )
+    }
 
     /**
-     * Subscribes for events in given KVDB.
+     * Generate subscription Query for the KVDB events.
      *
-     * @param kvdbId ID of the KVDB to subscribe
+     * @param eventType    type of event you listen for
+     * @param selectorType scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
      * @throws IllegalStateException thrown when instance is closed.
      * @throws PrivmxException       thrown when method encounters an exception.
      * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual external fun subscribeForEntryEvents(kvdbId: String)
-
-    /**
-     * Unsubscribes from events in given KVDB.
-     *
-     * @param kvdbId ID of the KVDB to unsubscribe
-     * @throws IllegalStateException thrown when instance is closed.
-     * @throws PrivmxException       thrown when method encounters an exception.
-     * @throws NativeException       thrown when method encounters an unknown exception.
-     */
-    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual external fun unsubscribeFromEntryEvents(kvdbId: String)
+    private external fun buildSubscriptionQuery(
+        eventType: Long,
+        selectorType: Long,
+        selectorId: String
+    ): String
 
     /**
      * Frees memory.

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/store/StoreApi.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/store/StoreApi.jvm.kt
@@ -17,6 +17,8 @@ import com.simplito.kotlin.privmx_endpoint.model.File
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.Store
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.StoreEventSelectorType
+import com.simplito.kotlin.privmx_endpoint.model.events.eventTypes.StoreEventType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -378,62 +380,58 @@ actual constructor(connection: Connection) : AutoCloseable {
     actual external fun closeFile(fileHandle: Long): String
 
     /**
-     * Subscribes for the Store module main events.
+     * Subscribe for the Store events on the given subscription query.
      *
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class,
-        NativeException::class,
-        IllegalStateException::class
-    )
-    actual external fun subscribeForStoreEvents()
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun subscribeFor(subscriptionQueries: List<String>): List<String>
 
     /**
-     * Unsubscribes from the Store module main events.
+     * Unsubscribe from events with the given subscriptionId.
      *
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class,
-        NativeException::class,
-        IllegalStateException::class
-    )
-    actual external fun unsubscribeFromStoreEvents()
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual external fun unsubscribeFrom(subscriptionIds: List<String>)
+
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    private external fun buildSubscriptionQuery(
+        eventType: Long,
+        selectorType: Long,
+        selectorId: String
+    ): String
 
     /**
-     * Subscribes for events in given Store.
+     * Generate subscription Query for the Store events.
      *
-     * @param storeId ID of the Store to subscribe
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param eventType    type of event you listen for
+     * @param selectorType scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
-    @Throws(
-        PrivmxException::class,
-        NativeException::class,
-        IllegalStateException::class
-    )
-    actual external fun subscribeForFileEvents(storeId: String)
-
-    /**
-     * Unsubscribes from events in given Store.
-     *
-     * @param storeId ID of the `Store` to unsubscribe
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     */
-    @Throws(
-        PrivmxException::class,
-        NativeException::class,
-        IllegalStateException::class
-    )
-    actual external fun unsubscribeFromFileEvents(storeId: String)
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    actual fun buildSubscriptionQuery(
+        eventType: StoreEventType,
+        selectorType: StoreEventSelectorType,
+        selectorId: String
+    ): String {
+        return buildSubscriptionQuery(
+            eventType.ordinal.toLong(),
+            selectorType.ordinal.toLong(),
+            selectorId
+        )
+    }
 
     @Throws(IllegalStateException::class)
     private external fun init(connection: Connection): Long?

--- a/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/thread/ThreadApi.jvm.kt
+++ b/privmx-endpoint/src/jvmMain/kotlin/com/simplito/kotlin/privmx_endpoint/modules/thread/ThreadApi.jvm.kt
@@ -17,6 +17,8 @@ import com.simplito.kotlin.privmx_endpoint.model.Message
 import com.simplito.kotlin.privmx_endpoint.model.PagingList
 import com.simplito.kotlin.privmx_endpoint.model.Thread
 import com.simplito.kotlin.privmx_endpoint.model.UserWithPubKey
+import com.simplito.kotlin.privmx_endpoint.model.events.eventSelectorTypes.ThreadEventSelectorType
+import com.simplito.kotlin.privmx_endpoint.model.events.eventTypes.ThreadEventType
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.NativeException
 import com.simplito.kotlin.privmx_endpoint.model.exceptions.PrivmxException
 import com.simplito.kotlin.privmx_endpoint.modules.core.Connection
@@ -239,46 +241,58 @@ actual constructor(connection: Connection) : AutoCloseable {
     )
 
     /**
-     * Subscribes for the Thread module main events.
+     * Subscribe for the Thread events on the given subscription query.
      *
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param subscriptionQueries list of queries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual external fun subscribeForThreadEvents()
+    actual external fun subscribeFor(subscriptionQueries: List<String>): List<String>
 
     /**
-     * Unsubscribes from the Thread module main events.
+     * Unsubscribe from events with the given subscriptionId.
      *
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param subscriptionIds list of subscriptionId
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual external fun unsubscribeFromThreadEvents()
+    actual external fun unsubscribeFrom(subscriptionIds: List<String>)
+
+    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
+    private external fun buildSubscriptionQuery(
+        eventType: Long,
+        selectorType: Long,
+        selectorId: String
+    ): String
 
     /**
-     * Subscribes for events in given Thread.
+     * Generate subscription Query for the Thread events.
      *
-     * @param threadId ID of the Thread to subscribe
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
+     * @param eventType    type of event you listen for
+     * @param selectorType scope on which you listen for events
+     * @param selectorId   ID of the selector
+     * @return Query for subscribing event
+     * @throws IllegalStateException thrown when instance is closed.
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
      */
     @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual external fun subscribeForMessageEvents(threadId: String)
-
-    /**
-     * Unsubscribes from events in given Thread.
-     *
-     * @param threadId ID of the Thread to unsubscribe
-     * @throws IllegalStateException thrown when instance is closed
-     * @throws PrivmxException       thrown when method encounters an exception
-     * @throws NativeException       thrown when method encounters an unknown exception
-     */
-    @Throws(PrivmxException::class, NativeException::class, IllegalStateException::class)
-    actual external fun unsubscribeFromMessageEvents(threadId: String)
+    actual fun buildSubscriptionQuery(
+        eventType: ThreadEventType,
+        selectorType: ThreadEventSelectorType,
+        selectorId: String
+    ): String {
+        return buildSubscriptionQuery(
+            eventType.ordinal.toLong(),
+            selectorType.ordinal.toLong(),
+            selectorId
+        )
+    }
 
     /**
      * Frees memory.


### PR DESCRIPTION
## Description

Implement new classes and enums added in 2.6.

### CHANGES

### New classes
- `StoreEventType`
- `ThreadEventType`
- `InboxEventType`
- `KvdbEventType`
- `EventSelectorType`
- `StoreEventSelectorType`
- `ThreadEventSelectorType`
- `InboxEventSelectorType`
- `KvdbEventSelectorType`
- `CustomEventSelectorType`